### PR TITLE
feat: add Dockerfile for building rift_tui and rift_server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+.direnv/
+.envrc
+result

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Stage 1: Build rift_tui and rift_server
+FROM debian:bookworm-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates \
+    pkg-config \
+    libssl-dev \
+    libasound2-dev \
+    clang \
+    libclang-dev \
+    cmake \
+    make \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain 1.93.0 --profile minimal
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+COPY assets/ assets/
+COPY static/ static/
+
+RUN cargo build --release -p rift_tui -p rift_server
+
+# Stage 2: Minimal runtime image
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl3 \
+    libasound2 \
+    ca-certificates \
+    fzf \
+    ripgrep \
+    fd-find \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/fdfind /usr/bin/fd
+
+COPY --from=builder /app/target/release/rt /usr/local/bin/rt
+COPY --from=builder /app/target/release/rift_server /usr/local/bin/rift_server
+COPY --from=builder /app/static /opt/rift/static
+
+WORKDIR /opt/rift
+
+EXPOSE 3000
+
+CMD ["rift_server"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ Prebuilt executables: [Latest release](https://github.com/satwik-kambham/rift/re
     nix run github:satwik-kambham/rift#rift_tui
   ```
 
+### Run with Docker
+
+- Build the image:
+  ```
+    docker build -t rift .
+  ```
+- Run the web server frontend:
+  ```
+    docker run -p 3000:3000 rift
+  ```
+- Run the TUI frontend:
+  ```
+    docker run -it rift rt
+  ```
+- Run without audio:
+  ```
+    docker run -p 3000:3000 rift rift_server --no-audio
+  ```
+
 ## Features
 
 - Modal Editing

--- a/crates/rift_server/src/server.rs
+++ b/crates/rift_server/src/server.rs
@@ -41,7 +41,7 @@ async fn start_axum_server(
         )
         .fallback_service(static_files);
     tokio::spawn(async move {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:3000")
             .await
             .unwrap();
         axum::serve(


### PR DESCRIPTION
Multi-stage build using debian:bookworm-slim that mirrors the Nix flake.
Also changes rift_server bind address to 0.0.0.0:3000 for Docker compatibility.

https://claude.ai/code/session_017gRkRe6UadAL4KWu8HSv7G