### PR TITLE
feat: async main loop with tokio::select!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix 0.38.44",
@@ -2588,6 +2589,8 @@ name = "rift_tui"
 version = "1.0.23"
 dependencies = [
  "anyhow",
+ "crossterm",
+ "futures",
  "ratatui",
  "rift_core",
  "strum 0.27.2",

--- a/crates/rift_core/src/actions.rs
+++ b/crates/rift_core/src/actions.rs
@@ -419,7 +419,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
             buffer.modified = false;
 
             if let Some(lsp_handle) = lsp_handle
-                && let Err(err) = lsp_handle.lock().unwrap().send_notification_sync(
+                && let Err(err) = lsp_handle.lock().unwrap().send_notification_nonblocking(
                     "textDocument/didSave".to_string(),
                     Some(LSPClientHandle::did_save_text_document(file_path)),
                 )
@@ -433,7 +433,9 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
             perform_action(Action::RunSource(source), state);
         }
         Action::RunSource(source) => {
-            state.rsl_sender.blocking_send(source).unwrap();
+            if let Err(err) = state.rsl_sender.try_send(source) {
+                tracing::warn!(%err, "Failed to send RSL source");
+            }
         }
         Action::Select(selection) => {
             let (_buffer, instance) = state.get_buffer_by_id_mut(state.buffer_idx.unwrap());
@@ -563,7 +565,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                 lsp_handle
                     .lock()
                     .unwrap()
-                    .send_request_sync(
+                    .send_request_nonblocking(
                         "textDocument/formatting".to_string(),
                         Some(LSPClientHandle::formatting_request(
                             buffer.file_path().cloned().unwrap(),
@@ -674,7 +676,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                 lsp_handle
                     .lock()
                     .unwrap()
-                    .send_request_sync(
+                    .send_request_nonblocking(
                         "textDocument/hover".to_string(),
                         Some(LSPClientHandle::hover_request(
                             buffer.file_path().cloned().unwrap(),
@@ -691,7 +693,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                 lsp_handle
                     .lock()
                     .unwrap()
-                    .send_request_sync(
+                    .send_request_nonblocking(
                         "textDocument/completion".to_string(),
                         Some(LSPClientHandle::completion_request(
                             buffer.file_path().cloned().unwrap(),
@@ -708,7 +710,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                 lsp_handle
                     .lock()
                     .unwrap()
-                    .send_request_sync(
+                    .send_request_nonblocking(
                         "textDocument/signatureHelp".to_string(),
                         Some(LSPClientHandle::signature_help_request(
                             buffer.file_path().cloned().unwrap(),
@@ -733,7 +735,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_request_sync(
+                        .send_request_nonblocking(
                             "textDocument/definition".to_string(),
                             Some(LSPClientHandle::go_to_definition_request(
                                 file_path.clone(),
@@ -779,7 +781,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_request_sync(
+                        .send_request_nonblocking(
                             "textDocument/references".to_string(),
                             Some(LSPClientHandle::go_to_references_request(
                                 file_path.clone(),
@@ -888,7 +890,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                             warn!(?err, "Failed to copy selection via wl-copy");
                         }
                     },
-                    &state.rt,
+                    &state.rt_handle,
                     state.async_handle.sender.clone(),
                     state.workspace_folder.clone(),
                 );
@@ -938,7 +940,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                         instance.selection.cursor = instance.cursor;
                         instance.selection.mark = instance.cursor;
                     },
-                    &state.rt,
+                    &state.rt_handle,
                     state.async_handle.sender.clone(),
                     state.workspace_folder.clone(),
                 );
@@ -1115,7 +1117,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
             match audio::start_transcription(
                 None,
                 callback,
-                &state.rt,
+                &state.rt_handle,
                 state.async_handle.sender.clone(),
             ) {
                 Ok(handle) => {

--- a/crates/rift_core/src/actions.rs
+++ b/crates/rift_core/src/actions.rs
@@ -419,7 +419,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
             buffer.modified = false;
 
             if let Some(lsp_handle) = lsp_handle
-                && let Err(err) = lsp_handle.lock().unwrap().send_notification_nonblocking(
+                && let Err(err) = lsp_handle.lock().unwrap().send_notification_sync(
                     "textDocument/didSave".to_string(),
                     Some(LSPClientHandle::did_save_text_document(file_path)),
                 )
@@ -565,7 +565,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                 lsp_handle
                     .lock()
                     .unwrap()
-                    .send_request_nonblocking(
+                    .send_request_sync(
                         "textDocument/formatting".to_string(),
                         Some(LSPClientHandle::formatting_request(
                             buffer.file_path().cloned().unwrap(),
@@ -676,7 +676,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                 lsp_handle
                     .lock()
                     .unwrap()
-                    .send_request_nonblocking(
+                    .send_request_sync(
                         "textDocument/hover".to_string(),
                         Some(LSPClientHandle::hover_request(
                             buffer.file_path().cloned().unwrap(),
@@ -693,7 +693,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                 lsp_handle
                     .lock()
                     .unwrap()
-                    .send_request_nonblocking(
+                    .send_request_sync(
                         "textDocument/completion".to_string(),
                         Some(LSPClientHandle::completion_request(
                             buffer.file_path().cloned().unwrap(),
@@ -710,7 +710,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                 lsp_handle
                     .lock()
                     .unwrap()
-                    .send_request_nonblocking(
+                    .send_request_sync(
                         "textDocument/signatureHelp".to_string(),
                         Some(LSPClientHandle::signature_help_request(
                             buffer.file_path().cloned().unwrap(),
@@ -735,7 +735,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_request_nonblocking(
+                        .send_request_sync(
                             "textDocument/definition".to_string(),
                             Some(LSPClientHandle::go_to_definition_request(
                                 file_path.clone(),
@@ -781,7 +781,7 @@ pub fn perform_action(action: Action, state: &mut EditorState) -> Option<String>
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_request_nonblocking(
+                        .send_request_sync(
                             "textDocument/references".to_string(),
                             Some(LSPClientHandle::go_to_references_request(
                                 file_path.clone(),

--- a/crates/rift_core/src/audio.rs
+++ b/crates/rift_core/src/audio.rs
@@ -144,7 +144,7 @@ pub fn list_input_devices() -> Result<Vec<InputDeviceInfo>, AudioError> {
 pub fn start_transcription(
     device_id: Option<String>,
     callback: TranscriptionCallback,
-    rt: &tokio::runtime::Runtime,
+    rt: &tokio::runtime::Handle,
     sender: Sender<AsyncResult>,
 ) -> Result<TranscriptionHandle, AudioError> {
     let host = cpal::default_host();
@@ -200,7 +200,7 @@ pub fn start_transcription(
         path,
         callback,
         sender,
-        rt_handle: rt.handle().clone(),
+        rt_handle: rt.clone(),
         stopped: AtomicBool::new(false),
     })
 }
@@ -569,7 +569,7 @@ pub fn start_tts(text: String, state: &mut EditorState) {
         "http://127.0.0.1:8000/tts".to_string(),
         body,
         tts_async_callback,
-        &state.rt,
+        &state.rt_handle,
         state.async_handle.sender.clone(),
     );
 }

--- a/crates/rift_core/src/buffer/rope_buffer.rs
+++ b/crates/rift_core/src/buffer/rope_buffer.rs
@@ -595,7 +595,7 @@ impl RopeBuffer {
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_notification_nonblocking(
+                        .send_notification_sync(
                             "textDocument/didChange".to_string(),
                             Some(LSPClientHandle::did_change_text_document(
                                 self.file_path.clone().unwrap(),
@@ -609,7 +609,7 @@ impl RopeBuffer {
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_notification_nonblocking(
+                        .send_notification_sync(
                             "textDocument/didChange".to_string(),
                             Some(LSPClientHandle::did_change_text_document(
                                 self.file_path.clone().unwrap(),
@@ -682,7 +682,7 @@ impl RopeBuffer {
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_notification_nonblocking(
+                        .send_notification_sync(
                             "textDocument/didChange".to_string(),
                             Some(LSPClientHandle::did_change_text_document(
                                 self.file_path.clone().unwrap(),
@@ -696,7 +696,7 @@ impl RopeBuffer {
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_notification_nonblocking(
+                        .send_notification_sync(
                             "textDocument/didChange".to_string(),
                             Some(LSPClientHandle::did_change_text_document(
                                 self.file_path.clone().unwrap(),

--- a/crates/rift_core/src/buffer/rope_buffer.rs
+++ b/crates/rift_core/src/buffer/rope_buffer.rs
@@ -595,7 +595,7 @@ impl RopeBuffer {
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_notification_sync(
+                        .send_notification_nonblocking(
                             "textDocument/didChange".to_string(),
                             Some(LSPClientHandle::did_change_text_document(
                                 self.file_path.clone().unwrap(),
@@ -609,7 +609,7 @@ impl RopeBuffer {
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_notification_sync(
+                        .send_notification_nonblocking(
                             "textDocument/didChange".to_string(),
                             Some(LSPClientHandle::did_change_text_document(
                                 self.file_path.clone().unwrap(),
@@ -682,7 +682,7 @@ impl RopeBuffer {
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_notification_sync(
+                        .send_notification_nonblocking(
                             "textDocument/didChange".to_string(),
                             Some(LSPClientHandle::did_change_text_document(
                                 self.file_path.clone().unwrap(),
@@ -696,7 +696,7 @@ impl RopeBuffer {
                     lsp_handle
                         .lock()
                         .unwrap()
-                        .send_notification_sync(
+                        .send_notification_nonblocking(
                             "textDocument/didChange".to_string(),
                             Some(LSPClientHandle::did_change_text_document(
                                 self.file_path.clone().unwrap(),

--- a/crates/rift_core/src/concurrent/cli.rs
+++ b/crates/rift_core/src/concurrent/cli.rs
@@ -15,7 +15,7 @@ pub struct ProgramArgs {
 pub fn run_command(
     program_args: ProgramArgs,
     callback: fn(Result<AsyncPayload, AsyncError>, state: &mut EditorState),
-    rt: &tokio::runtime::Runtime,
+    rt: &tokio::runtime::Handle,
     sender: Sender<AsyncResult>,
     current_dir: String,
 ) {
@@ -100,7 +100,7 @@ pub fn run_command(
 pub fn run_piped_commands(
     program_args: Vec<ProgramArgs>,
     callback: fn(Result<AsyncPayload, AsyncError>, state: &mut EditorState),
-    rt: &tokio::runtime::Runtime,
+    rt: &tokio::runtime::Handle,
     sender: Sender<AsyncResult>,
     current_dir: String,
 ) {

--- a/crates/rift_core/src/concurrent/mod.rs
+++ b/crates/rift_core/src/concurrent/mod.rs
@@ -44,7 +44,7 @@ pub struct AsyncResult {
 pub fn simple_callback(
     data: String,
     callback: fn(Result<AsyncPayload, AsyncError>, state: &mut EditorState),
-    rt: &tokio::runtime::Runtime,
+    rt: &tokio::runtime::Handle,
     sender: Sender<AsyncResult>,
 ) {
     rt.spawn(async move {

--- a/crates/rift_core/src/concurrent/web_api.rs
+++ b/crates/rift_core/src/concurrent/web_api.rs
@@ -7,7 +7,7 @@ use super::{AsyncError, AsyncPayload, AsyncResult};
 pub fn get_request(
     url: String,
     callback: fn(Result<AsyncPayload, AsyncError>, state: &mut EditorState),
-    rt: &tokio::runtime::Runtime,
+    rt: &tokio::runtime::Handle,
     sender: Sender<AsyncResult>,
 ) {
     rt.spawn(async move {
@@ -56,7 +56,7 @@ pub fn post_request(
     url: String,
     body: String,
     callback: fn(Result<AsyncPayload, AsyncError>, state: &mut EditorState),
-    rt: &tokio::runtime::Runtime,
+    rt: &tokio::runtime::Handle,
     sender: Sender<AsyncResult>,
 ) {
     rt.spawn(async move {
@@ -108,7 +108,7 @@ pub fn post_request_json_body_with_bearer_auth(
     body: serde_json::Value,
     bearer_auth_token: String,
     callback: fn(Result<AsyncPayload, AsyncError>, state: &mut EditorState),
-    rt: &tokio::runtime::Runtime,
+    rt: &tokio::runtime::Handle,
     sender: Sender<AsyncResult>,
 ) {
     rt.spawn(async move {
@@ -162,7 +162,7 @@ pub fn post_request_json_body_bytes(
     url: String,
     body: serde_json::Value,
     callback: fn(Result<AsyncPayload, AsyncError>, state: &mut EditorState),
-    rt: &tokio::runtime::Runtime,
+    rt: &tokio::runtime::Handle,
     sender: Sender<AsyncResult>,
 ) {
     rt.spawn(async move {

--- a/crates/rift_core/src/logging.rs
+++ b/crates/rift_core/src/logging.rs
@@ -1,6 +1,5 @@
 pub fn initialize_tracing() {
-    let mut tmp_dir = std::env::temp_dir();
-    tmp_dir.push("rift_logs");
+    let tmp_dir = std::path::PathBuf::from("/tmp/rift_logs");
 
     std::fs::create_dir_all(&tmp_dir).ok();
 

--- a/crates/rift_core/src/logging.rs
+++ b/crates/rift_core/src/logging.rs
@@ -1,5 +1,5 @@
 pub fn initialize_tracing() {
-    let tmp_dir = std::path::PathBuf::from("/tmp/rift_logs");
+    let tmp_dir = std::env::temp_dir().join("rift_logs");
 
     std::fs::create_dir_all(&tmp_dir).ok();
 

--- a/crates/rift_core/src/lsp/client.rs
+++ b/crates/rift_core/src/lsp/client.rs
@@ -22,7 +22,7 @@ fn next_id() -> usize {
     ID.fetch_add(1, Ordering::SeqCst)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum IncomingMessage {
     Response(types::ResponseMessage),
     Notification(types::NotificationMessage),
@@ -197,12 +197,11 @@ fn start_lsp_inner(
                     let _ = unified_tx
                         .send(super::LSPIncomingMessage {
                             language: lang,
-                            message: msg,
+                            message: msg.clone(),
                         })
                         .await;
-                } else {
-                    let _ = itx.send(msg).await;
                 }
+                let _ = itx.send(msg).await;
 
                 header = String::new();
             }

--- a/crates/rift_core/src/lsp/client.rs
+++ b/crates/rift_core/src/lsp/client.rs
@@ -58,7 +58,27 @@ pub struct LSPClientHandle {
     pub initialize_capabilities: Value,
 }
 
+pub async fn start_lsp_with_channel(
+    program: &str,
+    args: &[&str],
+    unified_tx: mpsc::Sender<super::LSPIncomingMessage>,
+    language: crate::buffer::instance::Language,
+) -> Result<LSPClientHandle> {
+    start_lsp_inner(program, args, Some((unified_tx, language))).await
+}
+
 pub async fn start_lsp(program: &str, args: &[&str]) -> Result<LSPClientHandle> {
+    start_lsp_inner(program, args, None).await
+}
+
+async fn start_lsp_inner(
+    program: &str,
+    args: &[&str],
+    unified_channel: Option<(
+        mpsc::Sender<super::LSPIncomingMessage>,
+        crate::buffer::instance::Language,
+    )>,
+) -> Result<LSPClientHandle> {
     let mut command = Command::new(program);
 
     let command_display = if args.is_empty() {
@@ -164,15 +184,24 @@ pub async fn start_lsp(program: &str, args: &[&str]) -> Result<LSPClientHandle> 
                 let body: Value = serde_json::from_str(&body).unwrap();
 
                 // If id is present then it is a response
-                if let Some(_id) = body.get("id") {
+                let msg = if let Some(_id) = body.get("id") {
                     let response: types::ResponseMessage = serde_json::from_value(body).unwrap();
-                    itx.send(IncomingMessage::Response(response)).await.unwrap();
+                    IncomingMessage::Response(response)
                 } else {
                     let notification: types::NotificationMessage =
                         serde_json::from_value(body).unwrap();
-                    itx.send(IncomingMessage::Notification(notification))
-                        .await
-                        .unwrap();
+                    IncomingMessage::Notification(notification)
+                };
+
+                if let Some((ref unified_tx, lang)) = unified_channel {
+                    let _ = unified_tx
+                        .send(super::LSPIncomingMessage {
+                            language: lang,
+                            message: msg,
+                        })
+                        .await;
+                } else {
+                    let _ = itx.send(msg).await;
                 }
 
                 header = String::new();
@@ -219,6 +248,18 @@ impl LSPClientHandle {
         Ok(())
     }
 
+    pub fn send_request_nonblocking(
+        &mut self,
+        method: String,
+        params: Option<Value>,
+    ) -> Result<()> {
+        let id = next_id();
+        self.id_method.insert(id, method.clone());
+        self.sender
+            .try_send(OutgoingMessage::Request(Request { method, params, id }))?;
+        Ok(())
+    }
+
     pub async fn send_response(
         &self,
         id: usize,
@@ -255,6 +296,19 @@ impl LSPClientHandle {
     pub fn send_notification_sync(&self, method: String, params: Option<Value>) -> Result<()> {
         self.sender
             .blocking_send(OutgoingMessage::Notification(Notification {
+                method,
+                params,
+            }))?;
+        Ok(())
+    }
+
+    pub fn send_notification_nonblocking(
+        &self,
+        method: String,
+        params: Option<Value>,
+    ) -> Result<()> {
+        self.sender
+            .try_send(OutgoingMessage::Notification(Notification {
                 method,
                 params,
             }))?;
@@ -363,6 +417,51 @@ impl LSPClientHandle {
         }
 
         Ok(())
+    }
+
+    /// Send initialize request and wait for response (async version)
+    pub async fn init_lsp(&mut self, workspace_folder: String) -> Result<()> {
+        self.send_request(
+            "initialize".to_string(),
+            Some(self.get_initialization_params(workspace_folder)),
+        )
+        .await?;
+
+        let timeout_duration = Duration::from_secs(5);
+        let timeout = tokio::time::timeout(timeout_duration, async {
+            loop {
+                if let Some(message) = self.receiver.recv().await {
+                    match &message {
+                        IncomingMessage::Response(response) => {
+                            self.pending_requests.insert(response.id, message);
+                        }
+                        IncomingMessage::Notification(_) => {
+                            continue;
+                        }
+                    }
+                    if self.pending_requests.contains_key(&self.pending_id) {
+                        let msg = self.pending_requests.remove(&self.pending_id);
+                        self.pending_id += 1;
+                        if let Some(IncomingMessage::Response(response)) = msg {
+                            self.initialize_capabilities =
+                                response.result.unwrap()["capabilities"].clone();
+                            self.send_notification("initialized".to_string(), Some(json!({})))
+                                .await
+                                .unwrap();
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        });
+
+        match timeout.await {
+            Ok(result) => result,
+            Err(_) => {
+                tracing::warn!("LSP Initialization timed out. Disabling LSP");
+                bail!("LSP Initialization timed out")
+            }
+        }
     }
 
     /// DidOpenTextDocument Notification

--- a/crates/rift_core/src/lsp/client.rs
+++ b/crates/rift_core/src/lsp/client.rs
@@ -58,20 +58,20 @@ pub struct LSPClientHandle {
     pub initialize_capabilities: Value,
 }
 
-pub async fn start_lsp_with_channel(
+pub fn start_lsp_with_channel(
     program: &str,
     args: &[&str],
     unified_tx: mpsc::Sender<super::LSPIncomingMessage>,
     language: crate::buffer::instance::Language,
 ) -> Result<LSPClientHandle> {
-    start_lsp_inner(program, args, Some((unified_tx, language))).await
+    start_lsp_inner(program, args, Some((unified_tx, language)))
 }
 
-pub async fn start_lsp(program: &str, args: &[&str]) -> Result<LSPClientHandle> {
-    start_lsp_inner(program, args, None).await
+pub fn start_lsp(program: &str, args: &[&str]) -> Result<LSPClientHandle> {
+    start_lsp_inner(program, args, None)
 }
 
-async fn start_lsp_inner(
+fn start_lsp_inner(
     program: &str,
     args: &[&str],
     unified_channel: Option<(
@@ -244,7 +244,7 @@ impl LSPClientHandle {
         let id = next_id();
         self.id_method.insert(id, method.clone());
         self.sender
-            .blocking_send(OutgoingMessage::Request(Request { method, params, id }))?;
+            .try_send(OutgoingMessage::Request(Request { method, params, id }))?;
         Ok(())
     }
 
@@ -279,7 +279,7 @@ impl LSPClientHandle {
         error: Option<types::ResponseError>,
     ) -> Result<()> {
         self.sender
-            .blocking_send(OutgoingMessage::Response(Response { id, result, error }))?;
+            .try_send(OutgoingMessage::Response(Response { id, result, error }))?;
         Ok(())
     }
 
@@ -295,7 +295,7 @@ impl LSPClientHandle {
 
     pub fn send_notification_sync(&self, method: String, params: Option<Value>) -> Result<()> {
         self.sender
-            .blocking_send(OutgoingMessage::Notification(Notification {
+            .try_send(OutgoingMessage::Notification(Notification {
                 method,
                 params,
             }))?;

--- a/crates/rift_core/src/lsp/client.rs
+++ b/crates/rift_core/src/lsp/client.rs
@@ -67,10 +67,6 @@ pub fn start_lsp_with_channel(
     start_lsp_inner(program, args, Some((unified_tx, language)))
 }
 
-pub fn start_lsp(program: &str, args: &[&str]) -> Result<LSPClientHandle> {
-    start_lsp_inner(program, args, None)
-}
-
 fn start_lsp_inner(
     program: &str,
     args: &[&str],
@@ -194,14 +190,21 @@ fn start_lsp_inner(
                 };
 
                 if let Some((ref unified_tx, lang)) = unified_channel {
-                    let _ = unified_tx
+                    // try_send to per-client channel (needed during init, non-blocking
+                    // so it won't hang after init when nothing consumes it)
+                    let _ = itx.try_send(msg.clone());
+                    if let Err(err) = unified_tx
                         .send(super::LSPIncomingMessage {
                             language: lang,
-                            message: msg.clone(),
+                            message: msg,
                         })
-                        .await;
+                        .await
+                    {
+                        tracing::warn!("Failed to send LSP message to unified channel: {err}");
+                    }
+                } else {
+                    let _ = itx.send(msg).await;
                 }
-                let _ = itx.send(msg).await;
 
                 header = String::new();
             }
@@ -247,18 +250,6 @@ impl LSPClientHandle {
         Ok(())
     }
 
-    pub fn send_request_nonblocking(
-        &mut self,
-        method: String,
-        params: Option<Value>,
-    ) -> Result<()> {
-        let id = next_id();
-        self.id_method.insert(id, method.clone());
-        self.sender
-            .try_send(OutgoingMessage::Request(Request { method, params, id }))?;
-        Ok(())
-    }
-
     pub async fn send_response(
         &self,
         id: usize,
@@ -293,19 +284,6 @@ impl LSPClientHandle {
     }
 
     pub fn send_notification_sync(&self, method: String, params: Option<Value>) -> Result<()> {
-        self.sender
-            .try_send(OutgoingMessage::Notification(Notification {
-                method,
-                params,
-            }))?;
-        Ok(())
-    }
-
-    pub fn send_notification_nonblocking(
-        &self,
-        method: String,
-        params: Option<Value>,
-    ) -> Result<()> {
         self.sender
             .try_send(OutgoingMessage::Notification(Notification {
                 method,

--- a/crates/rift_core/src/lsp/mod.rs
+++ b/crates/rift_core/src/lsp/mod.rs
@@ -1,12 +1,17 @@
 use crate::{
     actions::{Action, ReferenceEntry, open_info_modal_in_rsl, perform_action},
-    buffer::instance::{Cursor, Selection},
+    buffer::instance::{Cursor, Language, Selection},
     io::file_io,
     state::EditorState,
 };
 
 pub mod client;
 pub mod types;
+
+pub struct LSPIncomingMessage {
+    pub language: Language,
+    pub message: client::IncomingMessage,
+}
 
 pub fn parse_uri(uri: String) -> String {
     let uri = std::path::absolute(uri.strip_prefix("file:").unwrap().trim_start_matches("\\"))
@@ -46,6 +51,22 @@ fn reference_preview(file_path: &str, range: &Selection) -> String {
         .unwrap_or_default()
 }
 
+/// Process a single LSP incoming message (used by the async main loop)
+pub fn handle_lsp_message(msg: LSPIncomingMessage, state: &mut EditorState) {
+    let method = if let client::IncomingMessage::Response(ref response) = msg.message {
+        if let Some(lsp_handle) = state.lsp_handles.get(&msg.language) {
+            let lsp_handle = lsp_handle.lock().unwrap();
+            lsp_handle.id_method.get(&response.id).cloned()
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    process_lsp_message(msg.message, method, state);
+}
+
 pub fn handle_lsp_messages(state: &mut EditorState) {
     if let Some(buffer_idx) = state.buffer_idx
         && let Some(lsp_handle) = state.get_lsp_handle_for_buffer(buffer_idx)
@@ -62,197 +83,200 @@ pub fn handle_lsp_messages(state: &mut EditorState) {
         };
 
         if let Some(message) = message {
-            state.update_view = true;
-            match message {
-                client::IncomingMessage::Response(response) => {
-                    let method_name = method.as_deref().unwrap_or("");
+            process_lsp_message(message, method, state);
+        }
+    }
+}
 
-                    if let Some(error) = response.error.as_ref() {
-                        tracing::error!(
-                            "---Error: Message Id: {}\n\n{:#?}---\n",
-                            response.id,
-                            error
-                        );
-                    } else if method_name == "textDocument/hover" {
-                        if let Some(result) = response.result.as_ref() {
-                            let message = result["contents"]["value"]
-                                .as_str()
-                                .unwrap_or_default()
-                                .to_string();
-                            open_info_modal_in_rsl(state, &message);
-                        }
-                    } else if method_name == "textDocument/completion" {
-                        if let Some(result) = response.result.as_ref() {
-                            let (buffer, instance) = state.get_buffer_by_id(buffer_idx);
-                            let items = if result["items"].is_array() {
-                                result["items"].as_array().unwrap().clone()
-                            } else {
-                                result.as_array().unwrap().clone()
-                            };
-                            let mut completion_items = vec![];
-                            for item in items {
-                                let label = item["label"].as_str().unwrap().to_owned();
-                                if label.contains(&buffer.get_word_under_cursor(&instance.cursor)) {
-                                    if item["textEdit"].is_object() {
-                                        completion_items.push(types::CompletionItem {
-                                            label,
-                                            edit: types::TextEdit {
-                                                text: item["textEdit"]["newText"]
-                                                    .as_str()
-                                                    .unwrap()
-                                                    .to_owned(),
-                                                range: parse_range(&item["textEdit"]["range"]),
-                                            },
-                                        });
-                                    } else if item["insertText"].is_string() {
-                                        completion_items.push(types::CompletionItem {
-                                            label,
-                                            edit: types::TextEdit {
-                                                text: item["insertText"]
-                                                    .as_str()
-                                                    .unwrap()
-                                                    .to_owned(),
-                                                range: buffer
-                                                    .get_word_range_under_cursor(&instance.cursor),
-                                            },
-                                        });
-                                    } else {
-                                        completion_items.push(types::CompletionItem {
-                                            label,
-                                            edit: types::TextEdit {
-                                                text: item["label"].as_str().unwrap().to_owned(),
-                                                range: Selection {
-                                                    cursor: instance.cursor,
-                                                    mark: instance.cursor,
-                                                },
-                                            },
-                                        });
-                                    }
-                                }
-                            }
-                            state.completion_menu.open(completion_items);
-                        }
-                    } else if method_name == "textDocument/formatting" {
-                        if let Some(result) = response.result.as_ref() {
-                            let edits = result.as_array().unwrap().clone();
-                            for edit in edits.iter().rev() {
-                                let text_edit = types::TextEdit {
-                                    text: edit["newText"].as_str().unwrap().to_owned(),
-                                    range: parse_range(&edit["range"]),
-                                };
-                                perform_action(Action::DeleteText(text_edit.range), state);
-                                perform_action(
-                                    Action::InsertText(text_edit.text, text_edit.range.mark),
-                                    state,
-                                );
-                            }
-                        }
-                    } else if method_name == "textDocument/signatureHelp" {
-                        if let Some(result) = response.result.as_ref()
-                            && !result["signatures"].as_array().unwrap().is_empty()
-                        {
-                            let label =
-                                result["signatures"].as_array().unwrap().first().unwrap()["label"]
-                                    .as_str()
-                                    .unwrap()
-                                    .to_string();
-                            state.signature_information.content = label;
-                        }
-                    } else if method_name == "textDocument/definition" {
-                        if let Some(result) = response.result.as_ref() {
-                            let locations = if let Some(array) = result.as_array() {
-                                array.clone()
-                            } else {
-                                vec![result.clone()]
-                            };
+fn process_lsp_message(
+    message: client::IncomingMessage,
+    method: Option<String>,
+    state: &mut EditorState,
+) {
+    let buffer_idx = match state.buffer_idx {
+        Some(idx) => idx,
+        None => return,
+    };
 
-                            let mut definitions = vec![];
-                            for location in locations {
-                                let uri = parse_uri(location["uri"].as_str().unwrap().to_string());
-                                let range = parse_range(&location["range"]);
-                                definitions.push(ReferenceEntry {
-                                    preview: reference_preview(&uri, &range),
-                                    file_path: uri,
-                                    range,
+    state.update_view = true;
+    match message {
+        client::IncomingMessage::Response(response) => {
+            let method_name = method.as_deref().unwrap_or("");
+
+            if let Some(error) = response.error.as_ref() {
+                tracing::error!("---Error: Message Id: {}\n\n{:#?}---\n", response.id, error);
+            } else if method_name == "textDocument/hover" {
+                if let Some(result) = response.result.as_ref() {
+                    let message = result["contents"]["value"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_string();
+                    open_info_modal_in_rsl(state, &message);
+                }
+            } else if method_name == "textDocument/completion" {
+                if let Some(result) = response.result.as_ref() {
+                    let (buffer, instance) = state.get_buffer_by_id(buffer_idx);
+                    let items = if result["items"].is_array() {
+                        result["items"].as_array().unwrap().clone()
+                    } else {
+                        result.as_array().unwrap().clone()
+                    };
+                    let mut completion_items = vec![];
+                    for item in items {
+                        let label = item["label"].as_str().unwrap().to_owned();
+                        if label.contains(&buffer.get_word_under_cursor(&instance.cursor)) {
+                            if item["textEdit"].is_object() {
+                                completion_items.push(types::CompletionItem {
+                                    label,
+                                    edit: types::TextEdit {
+                                        text: item["textEdit"]["newText"]
+                                            .as_str()
+                                            .unwrap()
+                                            .to_owned(),
+                                        range: parse_range(&item["textEdit"]["range"]),
+                                    },
+                                });
+                            } else if item["insertText"].is_string() {
+                                completion_items.push(types::CompletionItem {
+                                    label,
+                                    edit: types::TextEdit {
+                                        text: item["insertText"].as_str().unwrap().to_owned(),
+                                        range: buffer.get_word_range_under_cursor(&instance.cursor),
+                                    },
+                                });
+                            } else {
+                                completion_items.push(types::CompletionItem {
+                                    label,
+                                    edit: types::TextEdit {
+                                        text: item["label"].as_str().unwrap().to_owned(),
+                                        range: Selection {
+                                            cursor: instance.cursor,
+                                            mark: instance.cursor,
+                                        },
+                                    },
                                 });
                             }
-
-                            state.definitions = definitions;
-                            state.definitions_version = state.definitions_version.saturating_add(1);
-                            perform_action(
-                                Action::RunSource("createGoToDefinition()".to_string()),
-                                state,
-                            );
                         }
-                    } else if method_name == "textDocument/references" {
-                        if let Some(result) = response.result.as_ref() {
-                            let mut references = vec![];
-                            if let Some(locations) = result.as_array() {
-                                for location in locations {
-                                    let uri =
-                                        parse_uri(location["uri"].as_str().unwrap().to_string());
-                                    let range = parse_range(&location["range"]);
-                                    references.push(ReferenceEntry {
-                                        preview: reference_preview(&uri, &range),
-                                        file_path: uri,
-                                        range,
-                                    });
-                                }
-                            }
-                            state.references = references;
-                            state.references_version = state.references_version.saturating_add(1);
-                            perform_action(
-                                Action::RunSource("createGoToReferences()".to_string()),
-                                state,
-                            );
-                        }
-                    } else {
-                        let message = format!(
-                            "---Response to: {}({})\n\n{:#?}---\n",
-                            method_name, response.id, response.result
+                    }
+                    state.completion_menu.open(completion_items);
+                }
+            } else if method_name == "textDocument/formatting" {
+                if let Some(result) = response.result.as_ref() {
+                    let edits = result.as_array().unwrap().clone();
+                    for edit in edits.iter().rev() {
+                        let text_edit = types::TextEdit {
+                            text: edit["newText"].as_str().unwrap().to_owned(),
+                            range: parse_range(&edit["range"]),
+                        };
+                        perform_action(Action::DeleteText(text_edit.range), state);
+                        perform_action(
+                            Action::InsertText(text_edit.text, text_edit.range.mark),
+                            state,
                         );
-                        tracing::info!("{}", message);
                     }
                 }
-                client::IncomingMessage::Notification(notification) => {
-                    if notification.method == "textDocument/publishDiagnostics"
-                        && let Some(params) = notification.params.as_ref()
-                    {
-                        let uri = parse_uri(params["uri"].as_str().unwrap().to_string());
+            } else if method_name == "textDocument/signatureHelp" {
+                if let Some(result) = response.result.as_ref()
+                    && !result["signatures"].as_array().unwrap().is_empty()
+                {
+                    let label = result["signatures"].as_array().unwrap().first().unwrap()["label"]
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                    state.signature_information.content = label;
+                }
+            } else if method_name == "textDocument/definition" {
+                if let Some(result) = response.result.as_ref() {
+                    let locations = if let Some(array) = result.as_array() {
+                        array.clone()
+                    } else {
+                        vec![result.clone()]
+                    };
 
-                        let mut diagnostics = types::PublishDiagnostics {
-                            uri,
-                            version: params["version"].as_u64().unwrap_or(0) as usize,
-                            diagnostics: vec![],
-                        };
+                    let mut definitions = vec![];
+                    for location in locations {
+                        let uri = parse_uri(location["uri"].as_str().unwrap().to_string());
+                        let range = parse_range(&location["range"]);
+                        definitions.push(ReferenceEntry {
+                            preview: reference_preview(&uri, &range),
+                            file_path: uri,
+                            range,
+                        });
+                    }
 
-                        for diagnostic in params["diagnostics"].as_array().unwrap() {
-                            diagnostics.diagnostics.push(types::Diagnostic {
-                                range: parse_range(&diagnostic["range"]),
-                                severity: match diagnostic["severity"].as_u64().unwrap_or(1) {
-                                    1 => types::DiagnosticSeverity::Error,
-                                    2 => types::DiagnosticSeverity::Warning,
-                                    3 => types::DiagnosticSeverity::Information,
-                                    4 => types::DiagnosticSeverity::Hint,
-                                    _ => types::DiagnosticSeverity::Error,
-                                },
-                                code: diagnostic["code"].to_string(),
-                                source: diagnostic["source"].to_string(),
-                                message: diagnostic["message"].to_string(),
+                    state.definitions = definitions;
+                    state.definitions_version = state.definitions_version.saturating_add(1);
+                    perform_action(
+                        Action::RunSource("createGoToDefinition()".to_string()),
+                        state,
+                    );
+                }
+            } else if method_name == "textDocument/references" {
+                if let Some(result) = response.result.as_ref() {
+                    let mut references = vec![];
+                    if let Some(locations) = result.as_array() {
+                        for location in locations {
+                            let uri = parse_uri(location["uri"].as_str().unwrap().to_string());
+                            let range = parse_range(&location["range"]);
+                            references.push(ReferenceEntry {
+                                preview: reference_preview(&uri, &range),
+                                file_path: uri,
+                                range,
                             });
                         }
-                        state
-                            .diagnostics
-                            .insert(diagnostics.uri.clone(), diagnostics);
-                    } else {
-                        let message = format!(
-                            "---Notification: {}\n\n{:#?}---\n",
-                            notification.method, notification.params
-                        );
-                        tracing::info!("{}", message);
-                        state.diagnostics_overlay.content = message;
                     }
+                    state.references = references;
+                    state.references_version = state.references_version.saturating_add(1);
+                    perform_action(
+                        Action::RunSource("createGoToReferences()".to_string()),
+                        state,
+                    );
                 }
+            } else {
+                let message = format!(
+                    "---Response to: {}({})\n\n{:#?}---\n",
+                    method_name, response.id, response.result
+                );
+                tracing::info!("{}", message);
+            }
+        }
+        client::IncomingMessage::Notification(notification) => {
+            if notification.method == "textDocument/publishDiagnostics"
+                && let Some(params) = notification.params.as_ref()
+            {
+                let uri = parse_uri(params["uri"].as_str().unwrap().to_string());
+
+                let mut diagnostics = types::PublishDiagnostics {
+                    uri,
+                    version: params["version"].as_u64().unwrap_or(0) as usize,
+                    diagnostics: vec![],
+                };
+
+                for diagnostic in params["diagnostics"].as_array().unwrap() {
+                    diagnostics.diagnostics.push(types::Diagnostic {
+                        range: parse_range(&diagnostic["range"]),
+                        severity: match diagnostic["severity"].as_u64().unwrap_or(1) {
+                            1 => types::DiagnosticSeverity::Error,
+                            2 => types::DiagnosticSeverity::Warning,
+                            3 => types::DiagnosticSeverity::Information,
+                            4 => types::DiagnosticSeverity::Hint,
+                            _ => types::DiagnosticSeverity::Error,
+                        },
+                        code: diagnostic["code"].to_string(),
+                        source: diagnostic["source"].to_string(),
+                        message: diagnostic["message"].to_string(),
+                    });
+                }
+                state
+                    .diagnostics
+                    .insert(diagnostics.uri.clone(), diagnostics);
+            } else {
+                let message = format!(
+                    "---Notification: {}\n\n{:#?}---\n",
+                    notification.method, notification.params
+                );
+                tracing::info!("{}", message);
+                state.diagnostics_overlay.content = message;
             }
         }
     }

--- a/crates/rift_core/src/lsp/mod.rs
+++ b/crates/rift_core/src/lsp/mod.rs
@@ -67,27 +67,6 @@ pub fn handle_lsp_message(msg: LSPIncomingMessage, state: &mut EditorState) {
     process_lsp_message(msg.message, method, state);
 }
 
-pub fn handle_lsp_messages(state: &mut EditorState) {
-    if let Some(buffer_idx) = state.buffer_idx
-        && let Some(lsp_handle) = state.get_lsp_handle_for_buffer(buffer_idx)
-    {
-        let (message, method) = {
-            let mut lsp_handle = lsp_handle.lock().unwrap();
-            let message = lsp_handle.recv_message_sync();
-            let method = if let Some(client::IncomingMessage::Response(ref response)) = message {
-                lsp_handle.id_method.get(&response.id).cloned()
-            } else {
-                None
-            };
-            (message, method)
-        };
-
-        if let Some(message) = message {
-            process_lsp_message(message, method, state);
-        }
-    }
-}
-
 fn process_lsp_message(
     message: client::IncomingMessage,
     method: Option<String>,

--- a/crates/rift_core/src/lsp/types/mod.rs
+++ b/crates/rift_core/src/lsp/types/mod.rs
@@ -12,7 +12,7 @@ pub struct RequestMessage {
     pub params: Option<Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponseMessage {
     pub jsonrpc: String,
     pub id: usize,
@@ -21,7 +21,7 @@ pub struct ResponseMessage {
     pub error: Option<ResponseError>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponseError {
     pub code: i32,
     pub message: String,
@@ -29,7 +29,7 @@ pub struct ResponseError {
     pub data: Option<Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotificationMessage {
     pub jsonrpc: String,
     pub method: String,

--- a/crates/rift_core/src/state.rs
+++ b/crates/rift_core/src/state.rs
@@ -9,6 +9,7 @@ use copypasta::ClipboardContext;
 use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Result as NotifyResult, Watcher};
 use petal::NoteStore;
 use rodio::OutputStreamBuilder;
+use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 
 use crate::{
@@ -22,7 +23,8 @@ use crate::{
     concurrent::{AsyncHandle, AsyncResult},
     keybinds::KeybindHandler,
     lsp::{
-        client::{LSPClientHandle, start_lsp},
+        LSPIncomingMessage,
+        client::{LSPClientHandle, start_lsp, start_lsp_with_channel},
         types,
     },
     preferences::Preferences,
@@ -57,13 +59,15 @@ pub struct EditorState {
     pub clipboard_ctx: Option<ClipboardContext>,
 
     // Handles
-    pub rt: tokio::runtime::Runtime,
+    pub rt_handle: Handle,
     pub async_handle: AsyncHandle,
     pub file_event_receiver: mpsc::Receiver<NotifyResult<Event>>,
     pub event_reciever: mpsc::Receiver<RPCRequest>,
     pub rsl_sender: mpsc::Sender<String>,
     pub file_watcher: Option<RecommendedWatcher>,
     pub lsp_handles: HashMap<Language, Arc<Mutex<LSPClientHandle>>>,
+    pub lsp_message_receiver: mpsc::Receiver<LSPIncomingMessage>,
+    lsp_message_sender: mpsc::Sender<LSPIncomingMessage>,
     pub transcription_handle: Option<audio::TranscriptionHandle>,
     pub tts_output_stream: Option<rodio::OutputStream>,
     pub note_store: Option<NoteStore>,
@@ -89,30 +93,20 @@ pub struct EditorState {
     pub audio_recording: bool,
 }
 
-impl Default for EditorState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl EditorState {
-    pub fn new() -> Self {
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-
+    pub fn new(rt_handle: Handle) -> Self {
         let (event_sender, event_reciever) = mpsc::channel::<RPCRequest>(32);
 
-        let rpc_client_transport = rt.block_on(start_rpc_server(event_sender));
+        let rpc_client_transport = rt_handle.block_on(start_rpc_server(event_sender));
 
         let (sender, receiver) = mpsc::channel::<AsyncResult>(32);
         let (file_event_sender, file_event_receiver) = mpsc::channel::<NotifyResult<Event>>(32);
+        let (lsp_message_sender, lsp_message_receiver) = mpsc::channel::<LSPIncomingMessage>(32);
 
-        let rt_handle = rt.handle().clone();
+        let rt_handle_watcher = rt_handle.clone();
         let watcher = RecommendedWatcher::new(
             move |res| {
-                rt_handle.block_on(async {
+                rt_handle_watcher.block_on(async {
                     if let Err(err) = file_event_sender.clone().send(res).await {
                         tracing::warn!(%err, "Failed to forward file watcher event");
                     }
@@ -134,12 +128,14 @@ impl EditorState {
 
         Self {
             quit: false,
-            rt,
+            rt_handle,
             async_handle: AsyncHandle { sender, receiver },
             file_event_receiver,
             event_reciever,
             rsl_sender,
             file_watcher: watcher,
+            lsp_message_receiver,
+            lsp_message_sender,
             preferences: Preferences::default(),
             buffers: HashMap::new(),
             next_id: 0,
@@ -307,6 +303,45 @@ impl EditorState {
         None
     }
 
+    pub async fn spawn_lsp_async(&self, language: &Language) -> Option<LSPClientHandle> {
+        if self.preferences.no_lsp {
+            return None;
+        }
+
+        let command: Option<(&str, &[&str])> = match language {
+            Language::Rust => Some(("rust-analyzer", &[])),
+            Language::Python => Some(("uv", &["run", "pylsp"])),
+            Language::Dart => Some(("dart", &["language-server", "--client-id=rift"])),
+            Language::Zig => Some(("zls", &[])),
+            _ => None,
+        };
+        if let Some(command) = command {
+            if which::which(command.0).is_ok() {
+                match start_lsp_with_channel(
+                    command.0,
+                    command.1,
+                    self.lsp_message_sender.clone(),
+                    *language,
+                )
+                .await
+                {
+                    Ok(client) => return Some(client),
+                    Err(err) => {
+                        let command_display = if command.1.is_empty() {
+                            command.0.to_string()
+                        } else {
+                            format!("{} {}", command.0, command.1.join(" "))
+                        };
+                        tracing::error!("Failed to start LSP `{}`: {err}", command_display);
+                    }
+                }
+            } else {
+                return None;
+            }
+        }
+        None
+    }
+
     pub fn spawn_lsp(&self, language: &Language) -> Option<LSPClientHandle> {
         if self.preferences.no_lsp {
             return None;
@@ -317,19 +352,12 @@ impl EditorState {
             Language::Python => Some(("uv", &["run", "pylsp"])),
             Language::Dart => Some(("dart", &["language-server", "--client-id=rift"])),
             Language::Zig => Some(("zls", &[])),
-            // Language::HTML => Some(("vscode-html-language-server", &["--stdio"])),
-            // Language::CSS => Some(("vscode-css-language-server", &["--stdio"])),
-            // Language::JSON => Some(("vscode-json-language-server", &["--stdio"])),
-            // Language::Javascript => Some(("typescript-language-server", &["--stdio"])),
-            // Language::Typescript => Some(("typescript-language-server", &["--stdio"])),
-            // Language::Tsx => Some(("typescript-language-server", &["--stdio"])),
-            // Language::Vue => Some(("vue-language-server", &["--stdio"])),
             _ => None,
         };
         if let Some(command) = command {
             if which::which(command.0).is_ok() {
                 match self
-                    .rt
+                    .rt_handle
                     .block_on(async { start_lsp(command.0, command.1).await })
                 {
                     Ok(client) => return Some(client),
@@ -347,6 +375,23 @@ impl EditorState {
             }
         }
         None
+    }
+
+    pub async fn start_lsp_async(&mut self, language: &Language) {
+        if !self.lsp_handles.contains_key(language)
+            && let Some(mut lsp_handle) = self.spawn_lsp_async(language).await
+        {
+            if lsp_handle
+                .init_lsp(self.workspace_folder.clone())
+                .await
+                .is_ok()
+            {
+                self.lsp_handles
+                    .insert(*language, Arc::new(Mutex::new(lsp_handle)));
+            } else {
+                self.preferences.no_lsp = true;
+            }
+        }
     }
 
     pub fn start_lsp(&mut self, language: &Language) {
@@ -390,7 +435,7 @@ impl EditorState {
                 || lsp_handle.initialize_capabilities["textDocumentSync"]["openClose"]
                     .as_bool()
                     .unwrap_or(false))
-                && let Err(err) = lsp_handle.send_notification_sync(
+                && let Err(err) = lsp_handle.send_notification_nonblocking(
                     "textDocument/didOpen".to_string(),
                     Some(LSPClientHandle::did_open_text_document(
                         path,

--- a/crates/rift_core/src/state.rs
+++ b/crates/rift_core/src/state.rs
@@ -303,43 +303,6 @@ impl EditorState {
         None
     }
 
-    pub fn spawn_lsp_with_channel(&self, language: &Language) -> Option<LSPClientHandle> {
-        if self.preferences.no_lsp {
-            return None;
-        }
-
-        let command: Option<(&str, &[&str])> = match language {
-            Language::Rust => Some(("rust-analyzer", &[])),
-            Language::Python => Some(("uv", &["run", "pylsp"])),
-            Language::Dart => Some(("dart", &["language-server", "--client-id=rift"])),
-            Language::Zig => Some(("zls", &[])),
-            _ => None,
-        };
-        if let Some(command) = command {
-            if which::which(command.0).is_ok() {
-                match start_lsp_with_channel(
-                    command.0,
-                    command.1,
-                    self.lsp_message_sender.clone(),
-                    *language,
-                ) {
-                    Ok(client) => return Some(client),
-                    Err(err) => {
-                        let command_display = if command.1.is_empty() {
-                            command.0.to_string()
-                        } else {
-                            format!("{} {}", command.0, command.1.join(" "))
-                        };
-                        tracing::error!("Failed to start LSP `{}`: {err}", command_display);
-                    }
-                }
-            } else {
-                return None;
-            }
-        }
-        None
-    }
-
     pub fn spawn_lsp(&self, language: &Language) -> Option<LSPClientHandle> {
         if self.preferences.no_lsp {
             return None;
@@ -379,7 +342,7 @@ impl EditorState {
 
     pub async fn start_lsp_async(&mut self, language: &Language) {
         if !self.lsp_handles.contains_key(language)
-            && let Some(mut lsp_handle) = self.spawn_lsp_with_channel(language)
+            && let Some(mut lsp_handle) = self.spawn_lsp(language)
         {
             if lsp_handle
                 .init_lsp(self.workspace_folder.clone())
@@ -435,7 +398,7 @@ impl EditorState {
                 || lsp_handle.initialize_capabilities["textDocumentSync"]["openClose"]
                     .as_bool()
                     .unwrap_or(false))
-                && let Err(err) = lsp_handle.send_notification_nonblocking(
+                && let Err(err) = lsp_handle.send_notification_sync(
                     "textDocument/didOpen".to_string(),
                     Some(LSPClientHandle::did_open_text_document(
                         path,

--- a/crates/rift_core/src/state.rs
+++ b/crates/rift_core/src/state.rs
@@ -24,7 +24,7 @@ use crate::{
     keybinds::KeybindHandler,
     lsp::{
         LSPIncomingMessage,
-        client::{LSPClientHandle, start_lsp, start_lsp_with_channel},
+        client::{LSPClientHandle, start_lsp_with_channel},
         types,
     },
     preferences::Preferences,
@@ -354,7 +354,12 @@ impl EditorState {
         };
         if let Some(command) = command {
             if which::which(command.0).is_ok() {
-                match start_lsp(command.0, command.1) {
+                match start_lsp_with_channel(
+                    command.0,
+                    command.1,
+                    self.lsp_message_sender.clone(),
+                    *language,
+                ) {
                     Ok(client) => return Some(client),
                     Err(err) => {
                         let command_display = if command.1.is_empty() {

--- a/crates/rift_core/src/state.rs
+++ b/crates/rift_core/src/state.rs
@@ -303,7 +303,7 @@ impl EditorState {
         None
     }
 
-    pub async fn spawn_lsp_async(&self, language: &Language) -> Option<LSPClientHandle> {
+    pub fn spawn_lsp_with_channel(&self, language: &Language) -> Option<LSPClientHandle> {
         if self.preferences.no_lsp {
             return None;
         }
@@ -322,9 +322,7 @@ impl EditorState {
                     command.1,
                     self.lsp_message_sender.clone(),
                     *language,
-                )
-                .await
-                {
+                ) {
                     Ok(client) => return Some(client),
                     Err(err) => {
                         let command_display = if command.1.is_empty() {
@@ -356,10 +354,7 @@ impl EditorState {
         };
         if let Some(command) = command {
             if which::which(command.0).is_ok() {
-                match self
-                    .rt_handle
-                    .block_on(async { start_lsp(command.0, command.1).await })
-                {
+                match start_lsp(command.0, command.1) {
                     Ok(client) => return Some(client),
                     Err(err) => {
                         let command_display = if command.1.is_empty() {
@@ -379,7 +374,7 @@ impl EditorState {
 
     pub async fn start_lsp_async(&mut self, language: &Language) {
         if !self.lsp_handles.contains_key(language)
-            && let Some(mut lsp_handle) = self.spawn_lsp_async(language).await
+            && let Some(mut lsp_handle) = self.spawn_lsp_with_channel(language)
         {
             if lsp_handle
                 .init_lsp(self.workspace_folder.clone())

--- a/crates/rift_server/src/main.rs
+++ b/crates/rift_server/src/main.rs
@@ -6,8 +6,12 @@ fn main() -> anyhow::Result<()> {
 
     tracing::info!("Rift session starting (server)");
 
-    let mut server = server::Server::new();
-    server.run()?;
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    let mut server = server::Server::new(rt.handle().clone());
+    server.run(&rt)?;
 
     tracing::info!("Rift session exiting (server)");
 

--- a/crates/rift_server/src/server.rs
+++ b/crates/rift_server/src/server.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, time::Duration};
+use std::net::SocketAddr;
 
 use axum::{
     extract::ConnectInfo,
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use serde_json::to_value;
 use tokio::sync::{broadcast, mpsc};
+use tokio::task::LocalSet;
 use tower_http::services::ServeDir;
 
 use petal::Block;
@@ -15,7 +16,7 @@ use rift_core::{
     actions::{Action, perform_action},
     audio::{build_temp_path, convert_webm_to_wav, transcribe_wav_file},
     io::file_io::handle_file_event,
-    lsp::handle_lsp_messages,
+    lsp::handle_lsp_message,
     rendering::update_visible_lines,
     state::EditorState,
 };
@@ -108,23 +109,15 @@ pub(crate) struct Server {
     viewport_columns: usize,
 }
 
-impl Default for Server {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Server {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(rt_handle: tokio::runtime::Handle) -> Self {
         let (sender_to_ws, _) = broadcast::channel::<WSMessage>(32);
         let (sender_from_ws, receiver_from_ws) = mpsc::channel::<WSMessage>(32);
 
-        let mut state = EditorState::new();
+        let mut state = EditorState::new(rt_handle.clone());
         state.post_initialization();
 
-        state
-            .rt
-            .block_on(async { start_axum_server(sender_to_ws.clone(), sender_from_ws).await });
+        rt_handle.block_on(async { start_axum_server(sender_to_ws.clone(), sender_from_ws).await });
 
         Self {
             state,
@@ -140,211 +133,214 @@ impl Server {
         perform_action(action, &mut self.state).unwrap_or_default()
     }
 
-    pub(crate) fn run(&mut self) -> anyhow::Result<()> {
-        while !self.state.quit {
-            // Run async callbacks
-            if let Ok(async_result) = self.state.async_handle.receiver.try_recv() {
-                (async_result.callback)(async_result.result, &mut self.state);
-                self.state.update_view = true;
-            }
+    pub(crate) fn run(&mut self, rt: &tokio::runtime::Runtime) -> anyhow::Result<()> {
+        let local = LocalSet::new();
+        local.block_on(rt, async {
+            loop {
+                if self.state.quit {
+                    break;
+                }
 
-            // Run action requests
-            while let Ok(action_request) = self.state.event_reciever.try_recv() {
-                let result = self.perform_action(action_request.action);
-                action_request.response_tx.send(result).unwrap();
-                self.state.update_view = true;
-                std::thread::sleep(Duration::from_millis(1));
-            }
+                // Update view and send to websocket connection
+                if self.state.update_view {
+                    self.state.relative_cursor = update_visible_lines(
+                        &mut self.state,
+                        self.viewport_rows,
+                        self.viewport_columns,
+                        true,
+                    );
 
-            // Handle file watcher events
-            if let Ok(file_event_result) = self.state.file_event_receiver.try_recv() {
-                handle_file_event(file_event_result, &mut self.state);
-                self.state.update_view = true;
-            }
-
-            // Handle lsp messages
-            handle_lsp_messages(&mut self.state);
-
-            // Handle websocket messages
-            if let Ok(message) = self.receiver_from_ws.try_recv() {
-                match message {
-                    WSMessage::Text(text) => {
-                        if let Ok(msg) = serde_json::from_str::<JsonMessage>(&text) {
-                            match msg.method.as_str() {
-                                "connected" => {
-                                    self.status = ConnectionStatus::Connected;
-                                    let initialize_data = InitializeData {
-                                        editor_font_size: self.state.preferences.editor_font_size,
-                                    };
-                                    let response = JsonMessage {
-                                        method: "initialize".to_string(),
-                                        data: Some(to_value(initialize_data).unwrap()),
-                                    };
-                                    if let Ok(json) = serde_json::to_string(&response) {
-                                        let _ = self.sender_to_ws.send(WSMessage::Text(json));
-                                    }
-                                }
-                                "initialized" => {
-                                    self.status = ConnectionStatus::Initialized;
-                                    if let Some(data) = msg.data {
-                                        if let Some(rows) =
-                                            data.get("viewport_rows").and_then(|v| v.as_u64())
-                                        {
-                                            self.viewport_rows = rows as usize;
-                                        }
-                                        if let Some(cols) =
-                                            data.get("viewport_columns").and_then(|v| v.as_u64())
-                                        {
-                                            self.viewport_columns = cols as usize;
-                                        }
-                                    }
-                                }
-                                "run_action" => {
-                                    if let Some(data) = msg.data
-                                        && let Some(action_name) = data.as_str()
-                                    {
-                                        self.perform_action(Action::RunAction(
-                                            action_name.to_string(),
-                                        ));
-                                    }
-                                }
-                                "ping" => {
-                                    let response = JsonMessage {
-                                        method: "pong".to_string(),
-                                        data: msg.data,
-                                    };
-                                    if let Ok(json) = serde_json::to_string(&response) {
-                                        let _ = self.sender_to_ws.send(WSMessage::Text(json));
-                                    }
-                                }
-                                _ => {
-                                    tracing::info!("Unknown method: {}", msg.method);
-                                }
-                            }
-                        }
-                    }
-                    WSMessage::Bytes(bytes) => {
-                        let webm_path = build_temp_path("webm");
-
-                        if let Err(e) = std::fs::write(&webm_path, &bytes) {
-                            tracing::error!("Failed to save audio recording: {}", e);
-                            continue;
-                        }
-                        tracing::info!("Saved audio recording to {}", webm_path.display());
-
-                        let wav_path = match convert_webm_to_wav(&webm_path) {
-                            Ok(path) => path,
-                            Err(e) => {
-                                tracing::error!("Failed to convert webm to wav: {}", e);
-                                continue;
-                            }
-                        };
-                        tracing::info!("Converted to wav: {}", wav_path.display());
-
-                        let wav_data = std::fs::read(&wav_path);
-                        let note_id = if let Some(ref store) = self.state.note_store
-                            && let Ok(wav_bytes) = &wav_data
-                        {
-                            match store.create_note() {
-                                Ok(mut note) => {
-                                    let wav_filename = wav_path
-                                        .file_name()
-                                        .unwrap_or_default()
-                                        .to_string_lossy()
-                                        .to_string();
-                                    match store.write_attachment(note.id, &wav_filename, wav_bytes)
-                                    {
-                                        Ok(block) => {
-                                            note.blocks.push(block);
-                                            if let Err(err) = store.save_note(note.clone()) {
-                                                tracing::warn!(
-                                                    %err,
-                                                    "Failed to save note with audio attachment"
-                                                );
-                                            }
-                                        }
-                                        Err(err) => {
-                                            tracing::warn!(
-                                                %err, "Failed to write audio attachment"
-                                            )
-                                        }
-                                    }
-                                    Some(note)
-                                }
-                                Err(err) => {
-                                    tracing::warn!(
-                                        %err, "Failed to create note for transcription"
-                                    );
-                                    None
-                                }
-                            }
-                        } else {
-                            None
-                        };
-
-                        let transcription = match transcribe_wav_file(wav_path.clone()) {
-                            Ok(text) => text,
-                            Err(e) => {
-                                tracing::error!("Failed to transcribe wav: {}", e);
-                                let _ = std::fs::remove_file(wav_path);
-                                continue;
-                            }
-                        };
-                        tracing::info!("Transcription: {}", transcription);
-
-                        let _ = std::fs::remove_file(wav_path);
-
-                        if let Some(ref store) = self.state.note_store
-                            && let Some(mut note) = note_id
-                        {
-                            let note_id = note.id;
-                            note.blocks.push(Block::Text {
-                                label: Some("transcription".to_string()),
-                                content: transcription.clone(),
-                            });
-                            if let Err(err) = store.save_note(note) {
-                                tracing::warn!(
-                                    %err, "Failed to save transcription to note"
-                                );
-                            }
-                            let note_file = store.note_path(note_id).to_string_lossy().to_string();
-                            perform_action(Action::OpenFile(note_file), &mut self.state);
-                        }
-
+                    if self.status == ConnectionStatus::Initialized {
                         let response = JsonMessage {
-                            method: "transcription".to_string(),
-                            data: Some(to_value(transcription).unwrap()),
+                            method: "render".to_string(),
+                            data: Some(to_value(&self.state.highlighted_text).unwrap()),
                         };
                         if let Ok(json) = serde_json::to_string(&response) {
                             let _ = self.sender_to_ws.send(WSMessage::Text(json));
                         }
                     }
+
+                    self.state.update_view = false;
                 }
-                self.state.update_view = true;
-            }
 
-            // Update view and send to websocket connection
-            if self.state.update_view {
-                self.state.relative_cursor = update_visible_lines(
-                    &mut self.state,
-                    self.viewport_rows,
-                    self.viewport_columns,
-                    true,
-                );
-
-                if self.status == ConnectionStatus::Initialized {
-                    let response = JsonMessage {
-                        method: "render".to_string(),
-                        data: Some(to_value(&self.state.highlighted_text).unwrap()),
-                    };
-                    if let Ok(json) = serde_json::to_string(&response) {
-                        let _ = self.sender_to_ws.send(WSMessage::Text(json));
+                tokio::select! {
+                    Some(req) = self.state.event_reciever.recv() => {
+                        let result = self.perform_action(req.action);
+                        req.response_tx.send(result).unwrap();
+                        self.state.update_view = true;
+                    }
+                    Some(async_result) = self.state.async_handle.receiver.recv() => {
+                        (async_result.callback)(async_result.result, &mut self.state);
+                        self.state.update_view = true;
+                    }
+                    Some(file_event) = self.state.file_event_receiver.recv() => {
+                        handle_file_event(file_event, &mut self.state);
+                        self.state.update_view = true;
+                    }
+                    Some(lsp_msg) = self.state.lsp_message_receiver.recv() => {
+                        handle_lsp_message(lsp_msg, &mut self.state);
+                        self.state.update_view = true;
+                    }
+                    Some(message) = self.receiver_from_ws.recv() => {
+                        self.handle_ws_message(message);
+                        self.state.update_view = true;
                     }
                 }
+            }
+        });
+        Ok(())
+    }
 
-                self.state.update_view = false;
+    fn handle_ws_message(&mut self, message: WSMessage) {
+        match message {
+            WSMessage::Text(text) => {
+                if let Ok(msg) = serde_json::from_str::<JsonMessage>(&text) {
+                    match msg.method.as_str() {
+                        "connected" => {
+                            self.status = ConnectionStatus::Connected;
+                            let initialize_data = InitializeData {
+                                editor_font_size: self.state.preferences.editor_font_size,
+                            };
+                            let response = JsonMessage {
+                                method: "initialize".to_string(),
+                                data: Some(to_value(initialize_data).unwrap()),
+                            };
+                            if let Ok(json) = serde_json::to_string(&response) {
+                                let _ = self.sender_to_ws.send(WSMessage::Text(json));
+                            }
+                        }
+                        "initialized" => {
+                            self.status = ConnectionStatus::Initialized;
+                            if let Some(data) = msg.data {
+                                if let Some(rows) =
+                                    data.get("viewport_rows").and_then(|v| v.as_u64())
+                                {
+                                    self.viewport_rows = rows as usize;
+                                }
+                                if let Some(cols) =
+                                    data.get("viewport_columns").and_then(|v| v.as_u64())
+                                {
+                                    self.viewport_columns = cols as usize;
+                                }
+                            }
+                        }
+                        "run_action" => {
+                            if let Some(data) = msg.data
+                                && let Some(action_name) = data.as_str()
+                            {
+                                self.perform_action(Action::RunAction(action_name.to_string()));
+                            }
+                        }
+                        "ping" => {
+                            let response = JsonMessage {
+                                method: "pong".to_string(),
+                                data: msg.data,
+                            };
+                            if let Ok(json) = serde_json::to_string(&response) {
+                                let _ = self.sender_to_ws.send(WSMessage::Text(json));
+                            }
+                        }
+                        _ => {
+                            tracing::info!("Unknown method: {}", msg.method);
+                        }
+                    }
+                }
+            }
+            WSMessage::Bytes(bytes) => {
+                let webm_path = build_temp_path("webm");
+
+                if let Err(e) = std::fs::write(&webm_path, &bytes) {
+                    tracing::error!("Failed to save audio recording: {}", e);
+                    return;
+                }
+                tracing::info!("Saved audio recording to {}", webm_path.display());
+
+                let wav_path = match convert_webm_to_wav(&webm_path) {
+                    Ok(path) => path,
+                    Err(e) => {
+                        tracing::error!("Failed to convert webm to wav: {}", e);
+                        return;
+                    }
+                };
+                tracing::info!("Converted to wav: {}", wav_path.display());
+
+                let wav_data = std::fs::read(&wav_path);
+                let note_id = if let Some(ref store) = self.state.note_store
+                    && let Ok(wav_bytes) = &wav_data
+                {
+                    match store.create_note() {
+                        Ok(mut note) => {
+                            let wav_filename = wav_path
+                                .file_name()
+                                .unwrap_or_default()
+                                .to_string_lossy()
+                                .to_string();
+                            match store.write_attachment(note.id, &wav_filename, wav_bytes) {
+                                Ok(block) => {
+                                    note.blocks.push(block);
+                                    if let Err(err) = store.save_note(note.clone()) {
+                                        tracing::warn!(
+                                            %err,
+                                            "Failed to save note with audio attachment"
+                                        );
+                                    }
+                                }
+                                Err(err) => {
+                                    tracing::warn!(
+                                        %err, "Failed to write audio attachment"
+                                    )
+                                }
+                            }
+                            Some(note)
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                %err, "Failed to create note for transcription"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let transcription = match transcribe_wav_file(wav_path.clone()) {
+                    Ok(text) => text,
+                    Err(e) => {
+                        tracing::error!("Failed to transcribe wav: {}", e);
+                        let _ = std::fs::remove_file(wav_path);
+                        return;
+                    }
+                };
+                tracing::info!("Transcription: {}", transcription);
+
+                let _ = std::fs::remove_file(wav_path);
+
+                if let Some(ref store) = self.state.note_store
+                    && let Some(mut note) = note_id
+                {
+                    let note_id = note.id;
+                    note.blocks.push(Block::Text {
+                        label: Some("transcription".to_string()),
+                        content: transcription.clone(),
+                    });
+                    if let Err(err) = store.save_note(note) {
+                        tracing::warn!(
+                            %err, "Failed to save transcription to note"
+                        );
+                    }
+                    let note_file = store.note_path(note_id).to_string_lossy().to_string();
+                    perform_action(Action::OpenFile(note_file), &mut self.state);
+                }
+
+                let response = JsonMessage {
+                    method: "transcription".to_string(),
+                    data: Some(to_value(transcription).unwrap()),
+                };
+                if let Ok(json) = serde_json::to_string(&response) {
+                    let _ = self.sender_to_ws.send(WSMessage::Text(json));
+                }
             }
         }
-        Ok(())
     }
 }

--- a/crates/rift_tui/Cargo.toml
+++ b/crates/rift_tui/Cargo.toml
@@ -9,7 +9,9 @@ path = "src/main.rs"
 
 [dependencies]
 rift_core = { path = "../rift_core" }
-ratatui = "0.29.0"
+ratatui = { version = "0.29.0", features = ["crossterm"] }
+crossterm = { version = "0.28", features = ["event-stream"] }
+futures = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rift_tui/src/app.rs
+++ b/crates/rift_tui/src/app.rs
@@ -1,18 +1,20 @@
-use std::{collections::HashSet, time::Duration};
+use std::collections::HashSet;
 
+use futures::StreamExt;
 use ratatui::{
     DefaultTerminal,
-    crossterm::event::{self, KeyCode, KeyEventKind, KeyModifiers},
+    crossterm::event::{EventStream, KeyCode, KeyEventKind, KeyModifiers},
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text, widgets,
 };
+use tokio::task::LocalSet;
 
 use rift_core::{
     actions::{Action, perform_action},
     buffer::instance::{HighlightType, TextAttributes},
     io::file_io::handle_file_event,
-    lsp::handle_lsp_messages,
+    lsp::handle_lsp_message,
     rendering::update_visible_lines,
     state::{CompletionMenu, EditorState, Mode},
 };
@@ -23,15 +25,9 @@ pub(crate) struct App {
     pub state: EditorState,
 }
 
-impl Default for App {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl App {
-    pub(crate) fn new() -> Self {
-        let mut state = EditorState::new();
+    pub(crate) fn new(rt_handle: tokio::runtime::Handle) -> Self {
+        let mut state = EditorState::new(rt_handle);
         state.post_initialization();
 
         Self { state }
@@ -41,468 +37,486 @@ impl App {
         perform_action(action, &mut self.state).unwrap_or_default()
     }
 
-    pub(crate) fn run(&mut self, mut terminal: DefaultTerminal) -> anyhow::Result<()> {
-        while !self.state.quit {
-            terminal.draw(|frame| {
-                let show_gutter = !matches!(self.state.is_active_buffer_special(), Some(true));
-                let gutter_width = if show_gutter {
-                    if let Some(buffer_idx) = self.state.buffer_idx {
-                        let (buffer, _) = self.state.get_buffer_by_id(buffer_idx);
-                        let line_count = buffer.get_num_lines().max(1);
-                        let digits = line_count.to_string().len();
-                        ((digits + 2).max(3)) as u16
-                    } else {
-                        0
+    pub(crate) fn run(
+        &mut self,
+        rt: &tokio::runtime::Runtime,
+        mut terminal: DefaultTerminal,
+    ) -> anyhow::Result<()> {
+        let local = LocalSet::new();
+        local.block_on(rt, async {
+            let mut event_stream = EventStream::new();
+
+            loop {
+                if self.state.quit {
+                    break;
+                }
+
+                // Render if needed
+                if self.state.update_view {
+                    self.render(&mut terminal);
+                }
+
+                tokio::select! {
+                    Some(req) = self.state.event_reciever.recv() => {
+                        let result = self.perform_action(req.action);
+                        req.response_tx.send(result).unwrap();
+                        self.state.update_view = true;
                     }
-                } else {
-                    0
-                };
-                let v_layout = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([Constraint::Fill(1), Constraint::Length(1)])
-                    .split(frame.area());
-                let h_layout = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .constraints(if show_gutter {
-                        vec![Constraint::Length(gutter_width), Constraint::Fill(1)]
-                    } else {
-                        vec![Constraint::Length(0), Constraint::Fill(1)]
-                    })
-                    .split(v_layout[0]);
+                    Some(async_result) = self.state.async_handle.receiver.recv() => {
+                        (async_result.callback)(async_result.result, &mut self.state);
+                        self.state.update_view = true;
+                    }
+                    Some(file_event) = self.state.file_event_receiver.recv() => {
+                        handle_file_event(file_event, &mut self.state);
+                        self.state.update_view = true;
+                    }
+                    Some(lsp_msg) = self.state.lsp_message_receiver.recv() => {
+                        handle_lsp_message(lsp_msg, &mut self.state);
+                        self.state.update_view = true;
+                    }
+                    Some(Ok(event)) = event_stream.next() => {
+                        self.handle_crossterm_event(event);
+                    }
+                }
+            }
+        });
 
-                let viewport_rows = h_layout[1].height as usize;
-                let viewport_columns = h_layout[1].width as usize;
+        Ok(())
+    }
 
-                // Update if resized
-                if self
-                    .state
-                    .set_viewport_size(viewport_rows, viewport_columns)
+    fn handle_crossterm_event(&mut self, event: crossterm::event::Event) {
+        if let crossterm::event::Event::Key(key) = event {
+            self.state.update_view = true;
+            if key.kind == KeyEventKind::Press {
+                if !(self.state.completion_menu.active
+                    && (key.code == KeyCode::Tab || key.code == KeyCode::Enter))
                 {
-                    self.state.update_view = true;
-                    if self.state.init_rsl_complete {
-                        let _ = self.perform_action(Action::RunSource(format!(
-                            "onViewportSizeChanged({}, {})",
-                            viewport_rows, viewport_columns
-                        )));
-                    }
-                }
-
-                if let Ok(async_result) = self.state.async_handle.receiver.try_recv() {
-                    (async_result.callback)(async_result.result, &mut self.state);
-                    self.state.update_view = true;
-                }
-
-                while let Ok(action_request) = self.state.event_reciever.try_recv() {
-                    let result = self.perform_action(action_request.action);
-                    action_request.response_tx.send(result).unwrap();
-                    self.state.update_view = true;
-                    std::thread::sleep(Duration::from_millis(1));
-                }
-
-                // Handle file watcher events
-                if let Ok(file_event_result) = self.state.file_event_receiver.try_recv() {
-                    handle_file_event(file_event_result, &mut self.state);
-                    self.state.update_view = true;
-                }
-
-                handle_lsp_messages(&mut self.state);
-
-                if let Some(buffer_idx) = self.state.buffer_idx {
-                    // Compute view if updated
-                    if self.state.update_view {
-                        self.state.relative_cursor = update_visible_lines(
-                            &mut self.state,
-                            viewport_rows,
-                            viewport_columns,
-                            false,
-                        );
-                        self.state.update_view = false;
-                    }
-
-                    // Render text
-                    let mut lines = vec![];
-                    for line in &self.state.highlighted_text {
-                        let mut line_widget = vec![];
-                        for token in line {
-                            let mut style = Style::new();
-                            let attributes = token.1;
-
-                            if let Some(highlight_type) = attributes.resolve_highlight() {
-                                match highlight_type {
-                                    HighlightType::None => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_none,
-                                        ));
-                                    }
-                                    HighlightType::White => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_white,
-                                        ));
-                                    }
-                                    HighlightType::Red => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_red,
-                                        ));
-                                    }
-                                    HighlightType::Orange => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_orange,
-                                        ));
-                                    }
-                                    HighlightType::Blue => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_blue,
-                                        ));
-                                    }
-                                    HighlightType::Green => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_green,
-                                        ));
-                                    }
-                                    HighlightType::Purple => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_purple,
-                                        ));
-                                    }
-                                    HighlightType::Yellow => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_yellow,
-                                        ));
-                                    }
-                                    HighlightType::Gray => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_gray,
-                                        ));
-                                    }
-                                    HighlightType::Turquoise => {
-                                        style = style.fg(color_from_rgb(
-                                            self.state.preferences.theme.highlight_turquoise,
-                                        ));
-                                    }
-                                }
-                            }
-
-                            if attributes.contains(TextAttributes::UNDERLINE)
-                                || attributes.has_diagnostic()
-                            {
-                                style = style.add_modifier(Modifier::UNDERLINED);
-                            }
-
-                            if attributes.contains(TextAttributes::SELECT) {
-                                style = style
-                                    .bg(color_from_rgb(self.state.preferences.theme.selection_bg));
-                            }
-
-                            if attributes.contains(TextAttributes::CURSOR) {
-                                if matches!(self.state.mode, Mode::Normal) {
-                                    style = style.fg(color_from_rgb(
-                                        self.state.preferences.theme.cursor_normal_mode_fg,
-                                    ));
-                                    style = style.bg(color_from_rgb(
-                                        self.state.preferences.theme.cursor_normal_mode_bg,
-                                    ));
-                                } else {
-                                    style = style.fg(color_from_rgb(
-                                        self.state.preferences.theme.cursor_insert_mode_fg,
-                                    ));
-                                    style = style.bg(color_from_rgb(
-                                        self.state.preferences.theme.cursor_insert_mode_bg,
-                                    ));
-                                }
-                            }
-                            line_widget.push(text::Span::styled(&token.0, style));
-                        }
-                        lines.push(text::Line::from(line_widget));
-                    }
-
-                    let editor_style =
-                        Style::new().bg(color_from_rgb(self.state.preferences.theme.editor_bg));
-                    let editor_text =
-                        widgets::Paragraph::new(text::Text::from(lines)).style(editor_style);
-                    frame.render_widget(editor_text, h_layout[1]);
-
-                    if show_gutter {
-                        // Render gutter
-                        let mut gutter_lines = vec![];
-                        for (idx, gutter_line) in self.state.gutter_info.iter().enumerate() {
-                            let gutter_value = if gutter_line.wrapped {
-                                ".  ".to_string()
-                            } else {
-                                format!("{}  ", gutter_line.start.row + 1)
-                            };
-                            if idx == self.state.relative_cursor.row {
-                                gutter_lines.push(
-                                    text::Line::styled(
-                                        gutter_value,
-                                        Style::new()
-                                            .fg(color_from_rgb(
-                                                self.state
-                                                    .preferences
-                                                    .theme
-                                                    .gutter_text_current_line,
-                                            ))
-                                            .bg(color_from_rgb(
-                                                self.state.preferences.theme.gutter_current_line_bg,
-                                            )),
-                                    )
-                                    .alignment(ratatui::layout::Alignment::Right),
-                                );
-                            } else {
-                                gutter_lines.push(
-                                    text::Line::styled(
-                                        gutter_value,
-                                        Style::new().fg(color_from_rgb(
-                                            self.state.preferences.theme.gutter_text,
-                                        )),
-                                    )
-                                    .alignment(ratatui::layout::Alignment::Right),
-                                );
-                            }
-                        }
-                        let gutter_style = Style::new()
-                            .bg(color_from_rgb(self.state.preferences.theme.gutter_bg))
-                            .fg(color_from_rgb(self.state.preferences.theme.gutter_text));
-                        let gutter_text = widgets::Paragraph::new(text::Text::from(gutter_lines))
-                            .style(gutter_style)
-                            .alignment(ratatui::layout::Alignment::Right);
-                        frame.render_widget(gutter_text, h_layout[0]);
-                    }
-
-                    // Render status line
-                    let status_mode_style = Style::default()
-                        .fg(color_from_rgb(self.state.preferences.theme.status_bar_bg))
-                        .bg(color_from_rgb(if matches!(self.state.mode, Mode::Normal) {
-                            self.state.preferences.theme.status_bar_normal_mode_fg
-                        } else {
-                            self.state.preferences.theme.status_bar_insert_mode_fg
-                        }));
-                    let status_bar_style = Style::new()
-                        .bg(color_from_rgb(self.state.preferences.theme.status_bar_bg))
-                        .fg(color_from_rgb(self.state.preferences.theme.ui_text));
-                    let (buffer, instance) = self.state.get_buffer_by_id(buffer_idx);
-                    let file_label = buffer
-                        .display_name
-                        .clone()
-                        .unwrap_or(buffer_idx.to_string());
-                    let mut left_spans = vec![text::Span::styled(
-                        format!(" {:#?} ", self.state.mode),
-                        status_mode_style,
-                    )];
-                    if self.state.audio_recording {
-                        left_spans.push(text::Span::styled(
-                            " ⏺ REC ".to_string(),
-                            Style::default().fg(color_from_rgb(self.state.preferences.theme.error)),
-                        ));
-                    }
-                    let left_file = format!(" {} ", file_label);
-                    left_spans.push(left_file.into());
-
-                    let cursor_label = format!(
-                        " {}:{} ",
-                        instance.cursor.row + 1,
-                        instance.cursor.column + 1,
-                    );
-                    let modified_label = format!(" {} ", if buffer.modified { "U" } else { "" });
-                    let keybind_label =
-                        format!(" {} ", self.state.keybind_handler.running_sequence);
-                    let log_label = format!(
-                        " {} ",
-                        self.state.log_messages.last().unwrap_or(&String::new())
-                    );
-                    let right_len = cursor_label.chars().count()
-                        + modified_label.chars().count()
-                        + keybind_label.chars().count()
-                        + log_label.chars().count();
-                    let status_area_width = v_layout[1].width as usize;
-                    let max_right = status_area_width.saturating_sub(10).max(1);
-                    let right_width = right_len.min(max_right).min(status_area_width) as u16;
-                    let status_layout = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints([Constraint::Min(1), Constraint::Length(right_width)])
-                        .split(v_layout[1]);
-                    let left_status = widgets::Paragraph::new(text::Line::from(left_spans))
-                        .style(status_bar_style);
-                    let right_status = widgets::Paragraph::new(text::Line::from(vec![
-                        cursor_label.into(),
-                        modified_label.into(),
-                        keybind_label.into(),
-                        log_label.into(),
-                    ]))
-                    .style(status_bar_style)
-                    .alignment(ratatui::layout::Alignment::Right);
-                    frame.render_widget(left_status, status_layout[0]);
-                    frame.render_widget(right_status, status_layout[1]);
-                }
-
-                // Render diagnostics overlay
-                if self.state.diagnostics_overlay.should_render() {
-                    let area = Rect {
-                        x: frame.area().width * 7 / 8 - 4,
-                        y: 2,
-                        width: frame.area().width / 8,
-                        height: frame.area().height - 4,
-                    };
-                    let diagnostics_info =
-                        widgets::Paragraph::new(self.state.diagnostics_overlay.content.clone())
-                            .wrap(widgets::Wrap { trim: false });
-                    frame.render_widget(diagnostics_info, area);
-                }
-
-                // Render signature information
-                if self.state.signature_information.should_render()
-                    && self.state.relative_cursor.row > 1
-                    && self.state.relative_cursor.row < self.state.viewport_rows().saturating_sub(1)
-                {
-                    let popup_area = Rect {
-                        x: self.state.relative_cursor.column as u16 + h_layout[1].x + 1,
-                        y: self.state.relative_cursor.row as u16 + h_layout[1].y - 1,
-                        width: (self.state.signature_information.content.len() as u16).min(
-                            frame.area().width
-                                - self.state.relative_cursor.column as u16
-                                - h_layout[1].x
-                                - 3,
-                        ),
-                        height: 1,
-                    };
-                    let signature_block = widgets::Block::default().style(
-                        Style::new()
-                            .bg(color_from_rgb(self.state.preferences.theme.modal_bg))
-                            .fg(color_from_rgb(self.state.preferences.theme.modal_text)),
-                    );
-
-                    let signature_information =
-                        widgets::Paragraph::new(self.state.signature_information.content.clone())
-                            .block(signature_block);
-                    frame.render_widget(widgets::Clear, popup_area);
-                    frame.render_widget(signature_information, popup_area);
-                }
-
-                // Render Completion Items
-                if self.state.completion_menu.active {
-                    let offset_y = if viewport_rows - self.state.completion_menu.max_items - 1
-                        < self.state.relative_cursor.row
-                    {
-                        self.state.completion_menu.max_items as u16
-                    } else {
-                        0
-                    };
-                    let popup_area = Rect {
-                        x: (self.state.relative_cursor.column as u16 + h_layout[1].x + 1)
-                            .min(frame.area().width - 35),
-                        y: self.state.relative_cursor.row as u16 + h_layout[1].y + 1 - offset_y,
-                        width: 30,
-                        height: self.state.completion_menu.max_items as u16,
-                    };
-                    let completion_list_block = widgets::Block::default().style(
-                        Style::new()
-                            .bg(color_from_rgb(self.state.preferences.theme.modal_bg))
-                            .fg(color_from_rgb(self.state.preferences.theme.modal_text)),
-                    );
-
-                    let completion_list = self
-                        .state
-                        .completion_menu
-                        .items
-                        .iter()
-                        .map(|item| item.label.clone())
-                        .collect::<widgets::List>()
-                        .highlight_style(
-                            Style::new()
-                                .fg(color_from_rgb(self.state.preferences.theme.modal_primary)),
-                        )
-                        .block(completion_list_block);
-                    frame.render_widget(widgets::Clear, popup_area);
-                    let mut list_state = widgets::ListState::default();
-                    list_state.select(self.state.completion_menu.selection);
-                    frame.render_stateful_widget(completion_list, popup_area, &mut list_state);
-                }
-            })?;
-
-            // Handle keyboard events
-            if event::poll(Duration::from_millis(5))?
-                && let event::Event::Key(key) = event::read()?
-            {
-                self.state.update_view = true;
-                if key.kind == KeyEventKind::Press {
-                    if !(self.state.completion_menu.active
-                        && (key.code == KeyCode::Tab || key.code == KeyCode::Enter))
-                    {
-                        let keybind = match key.code {
-                            KeyCode::Backspace => "Backspace",
-                            KeyCode::Enter => "Enter",
-                            KeyCode::Left => "Left",
-                            KeyCode::Right => "Right",
-                            KeyCode::Up => "Up",
-                            KeyCode::Down => "Down",
-                            KeyCode::Home => "Home",
-                            KeyCode::End => "End",
-                            KeyCode::PageUp => "PageUp",
-                            KeyCode::PageDown => "PageDown",
-                            KeyCode::Tab => "Tab",
-                            KeyCode::Delete => "Delete",
-                            KeyCode::Insert => "Insert",
-                            KeyCode::F(n) => match n {
-                                1 => "F1",
-                                2 => "F2",
-                                3 => "F3",
-                                4 => "F4",
-                                5 => "F5",
-                                6 => "F6",
-                                7 => "F7",
-                                8 => "F8",
-                                9 => "F9",
-                                10 => "F10",
-                                11 => "F11",
-                                12 => "F12",
-                                _ => "",
-                            },
-                            KeyCode::Char(c) => {
-                                if c == ' ' {
-                                    "Space"
-                                } else if c.is_ascii() {
-                                    &c.to_string()
-                                } else {
-                                    ""
-                                }
-                            }
-                            KeyCode::Esc => "Escape",
+                    let keybind = match key.code {
+                        KeyCode::Backspace => "Backspace",
+                        KeyCode::Enter => "Enter",
+                        KeyCode::Left => "Left",
+                        KeyCode::Right => "Right",
+                        KeyCode::Up => "Up",
+                        KeyCode::Down => "Down",
+                        KeyCode::Home => "Home",
+                        KeyCode::End => "End",
+                        KeyCode::PageUp => "PageUp",
+                        KeyCode::PageDown => "PageDown",
+                        KeyCode::Tab => "Tab",
+                        KeyCode::Delete => "Delete",
+                        KeyCode::Insert => "Insert",
+                        KeyCode::F(n) => match n {
+                            1 => "F1",
+                            2 => "F2",
+                            3 => "F3",
+                            4 => "F4",
+                            5 => "F5",
+                            6 => "F6",
+                            7 => "F7",
+                            8 => "F8",
+                            9 => "F9",
+                            10 => "F10",
+                            11 => "F11",
+                            12 => "F12",
                             _ => "",
-                        };
-                        let mut modifiers_set = HashSet::new();
-                        if key.modifiers.contains(KeyModifiers::ALT) {
-                            modifiers_set.insert("m".to_string());
-                        } else if key.modifiers.contains(KeyModifiers::CONTROL) {
-                            modifiers_set.insert("c".to_string());
-                        } else if key.modifiers.contains(KeyModifiers::SHIFT) {
-                            modifiers_set.insert("s".to_string());
+                        },
+                        KeyCode::Char(c) => {
+                            if c == ' ' {
+                                "Space"
+                            } else if c.is_ascii() {
+                                &c.to_string()
+                            } else {
+                                ""
+                            }
                         }
-
-                        if let Some(action) = self.state.keybind_handler.handle_input(
-                            self.state.buffer_idx,
-                            self.state.is_active_buffer_special(),
-                            self.state.mode.clone(),
-                            keybind.to_string(),
-                            modifiers_set,
-                        ) {
-                            perform_action(action, &mut self.state);
-                        }
+                        KeyCode::Esc => "Escape",
+                        _ => "",
+                    };
+                    let mut modifiers_set = HashSet::new();
+                    if key.modifiers.contains(KeyModifiers::ALT) {
+                        modifiers_set.insert("m".to_string());
+                    } else if key.modifiers.contains(KeyModifiers::CONTROL) {
+                        modifiers_set.insert("c".to_string());
+                    } else if key.modifiers.contains(KeyModifiers::SHIFT) {
+                        modifiers_set.insert("s".to_string());
                     }
 
-                    if self.state.completion_menu.active {
-                        if key.code == KeyCode::Esc {
-                            self.state.completion_menu.close();
-                            self.state.signature_information.content = String::new();
-                        } else if key.code == KeyCode::Tab {
-                            self.state.completion_menu.select_next();
-                        } else if key.code == KeyCode::Enter {
-                            let completion_item = self.state.completion_menu.select();
-                            CompletionMenu::on_select(completion_item, &mut self.state);
-                            self.state.signature_information.content = String::new();
-                        }
+                    if let Some(action) = self.state.keybind_handler.handle_input(
+                        self.state.buffer_idx,
+                        self.state.is_active_buffer_special(),
+                        self.state.mode.clone(),
+                        keybind.to_string(),
+                        modifiers_set,
+                    ) {
+                        perform_action(action, &mut self.state);
+                    }
+                }
+
+                if self.state.completion_menu.active {
+                    if key.code == KeyCode::Esc {
+                        self.state.completion_menu.close();
+                        self.state.signature_information.content = String::new();
+                    } else if key.code == KeyCode::Tab {
+                        self.state.completion_menu.select_next();
+                    } else if key.code == KeyCode::Enter {
+                        let completion_item = self.state.completion_menu.select();
+                        CompletionMenu::on_select(completion_item, &mut self.state);
+                        self.state.signature_information.content = String::new();
                     }
                 }
             }
         }
-        Ok(())
+    }
+
+    fn render(&mut self, terminal: &mut DefaultTerminal) {
+        let _ = terminal.draw(|frame| {
+            let show_gutter = !matches!(self.state.is_active_buffer_special(), Some(true));
+            let gutter_width = if show_gutter {
+                if let Some(buffer_idx) = self.state.buffer_idx {
+                    let (buffer, _) = self.state.get_buffer_by_id(buffer_idx);
+                    let line_count = buffer.get_num_lines().max(1);
+                    let digits = line_count.to_string().len();
+                    ((digits + 2).max(3)) as u16
+                } else {
+                    0
+                }
+            } else {
+                0
+            };
+            let v_layout = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Fill(1), Constraint::Length(1)])
+                .split(frame.area());
+            let h_layout = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints(if show_gutter {
+                    vec![Constraint::Length(gutter_width), Constraint::Fill(1)]
+                } else {
+                    vec![Constraint::Length(0), Constraint::Fill(1)]
+                })
+                .split(v_layout[0]);
+
+            let viewport_rows = h_layout[1].height as usize;
+            let viewport_columns = h_layout[1].width as usize;
+
+            // Update if resized
+            if self
+                .state
+                .set_viewport_size(viewport_rows, viewport_columns)
+            {
+                self.state.update_view = true;
+                if self.state.init_rsl_complete {
+                    let _ = self.perform_action(Action::RunSource(format!(
+                        "onViewportSizeChanged({}, {})",
+                        viewport_rows, viewport_columns
+                    )));
+                }
+            }
+
+            if let Some(buffer_idx) = self.state.buffer_idx {
+                // Compute view if updated
+                if self.state.update_view {
+                    self.state.relative_cursor = update_visible_lines(
+                        &mut self.state,
+                        viewport_rows,
+                        viewport_columns,
+                        false,
+                    );
+                    self.state.update_view = false;
+                }
+
+                // Render text
+                let mut lines = vec![];
+                for line in &self.state.highlighted_text {
+                    let mut line_widget = vec![];
+                    for token in line {
+                        let mut style = Style::new();
+                        let attributes = token.1;
+
+                        if let Some(highlight_type) = attributes.resolve_highlight() {
+                            match highlight_type {
+                                HighlightType::None => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_none,
+                                    ));
+                                }
+                                HighlightType::White => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_white,
+                                    ));
+                                }
+                                HighlightType::Red => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_red,
+                                    ));
+                                }
+                                HighlightType::Orange => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_orange,
+                                    ));
+                                }
+                                HighlightType::Blue => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_blue,
+                                    ));
+                                }
+                                HighlightType::Green => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_green,
+                                    ));
+                                }
+                                HighlightType::Purple => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_purple,
+                                    ));
+                                }
+                                HighlightType::Yellow => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_yellow,
+                                    ));
+                                }
+                                HighlightType::Gray => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_gray,
+                                    ));
+                                }
+                                HighlightType::Turquoise => {
+                                    style = style.fg(color_from_rgb(
+                                        self.state.preferences.theme.highlight_turquoise,
+                                    ));
+                                }
+                            }
+                        }
+
+                        if attributes.contains(TextAttributes::UNDERLINE)
+                            || attributes.has_diagnostic()
+                        {
+                            style = style.add_modifier(Modifier::UNDERLINED);
+                        }
+
+                        if attributes.contains(TextAttributes::SELECT) {
+                            style =
+                                style.bg(color_from_rgb(self.state.preferences.theme.selection_bg));
+                        }
+
+                        if attributes.contains(TextAttributes::CURSOR) {
+                            if matches!(self.state.mode, Mode::Normal) {
+                                style = style.fg(color_from_rgb(
+                                    self.state.preferences.theme.cursor_normal_mode_fg,
+                                ));
+                                style = style.bg(color_from_rgb(
+                                    self.state.preferences.theme.cursor_normal_mode_bg,
+                                ));
+                            } else {
+                                style = style.fg(color_from_rgb(
+                                    self.state.preferences.theme.cursor_insert_mode_fg,
+                                ));
+                                style = style.bg(color_from_rgb(
+                                    self.state.preferences.theme.cursor_insert_mode_bg,
+                                ));
+                            }
+                        }
+                        line_widget.push(text::Span::styled(&token.0, style));
+                    }
+                    lines.push(text::Line::from(line_widget));
+                }
+
+                let editor_style =
+                    Style::new().bg(color_from_rgb(self.state.preferences.theme.editor_bg));
+                let editor_text =
+                    widgets::Paragraph::new(text::Text::from(lines)).style(editor_style);
+                frame.render_widget(editor_text, h_layout[1]);
+
+                if show_gutter {
+                    // Render gutter
+                    let mut gutter_lines = vec![];
+                    for (idx, gutter_line) in self.state.gutter_info.iter().enumerate() {
+                        let gutter_value = if gutter_line.wrapped {
+                            ".  ".to_string()
+                        } else {
+                            format!("{}  ", gutter_line.start.row + 1)
+                        };
+                        if idx == self.state.relative_cursor.row {
+                            gutter_lines.push(
+                                text::Line::styled(
+                                    gutter_value,
+                                    Style::new()
+                                        .fg(color_from_rgb(
+                                            self.state.preferences.theme.gutter_text_current_line,
+                                        ))
+                                        .bg(color_from_rgb(
+                                            self.state.preferences.theme.gutter_current_line_bg,
+                                        )),
+                                )
+                                .alignment(ratatui::layout::Alignment::Right),
+                            );
+                        } else {
+                            gutter_lines.push(
+                                text::Line::styled(
+                                    gutter_value,
+                                    Style::new().fg(color_from_rgb(
+                                        self.state.preferences.theme.gutter_text,
+                                    )),
+                                )
+                                .alignment(ratatui::layout::Alignment::Right),
+                            );
+                        }
+                    }
+                    let gutter_style = Style::new()
+                        .bg(color_from_rgb(self.state.preferences.theme.gutter_bg))
+                        .fg(color_from_rgb(self.state.preferences.theme.gutter_text));
+                    let gutter_text = widgets::Paragraph::new(text::Text::from(gutter_lines))
+                        .style(gutter_style)
+                        .alignment(ratatui::layout::Alignment::Right);
+                    frame.render_widget(gutter_text, h_layout[0]);
+                }
+
+                // Render status line
+                let status_mode_style = Style::default()
+                    .fg(color_from_rgb(self.state.preferences.theme.status_bar_bg))
+                    .bg(color_from_rgb(if matches!(self.state.mode, Mode::Normal) {
+                        self.state.preferences.theme.status_bar_normal_mode_fg
+                    } else {
+                        self.state.preferences.theme.status_bar_insert_mode_fg
+                    }));
+                let status_bar_style = Style::new()
+                    .bg(color_from_rgb(self.state.preferences.theme.status_bar_bg))
+                    .fg(color_from_rgb(self.state.preferences.theme.ui_text));
+                let (buffer, instance) = self.state.get_buffer_by_id(buffer_idx);
+                let file_label = buffer
+                    .display_name
+                    .clone()
+                    .unwrap_or(buffer_idx.to_string());
+                let mut left_spans = vec![text::Span::styled(
+                    format!(" {:#?} ", self.state.mode),
+                    status_mode_style,
+                )];
+                if self.state.audio_recording {
+                    left_spans.push(text::Span::styled(
+                        " ⏺ REC ".to_string(),
+                        Style::default().fg(color_from_rgb(self.state.preferences.theme.error)),
+                    ));
+                }
+                let left_file = format!(" {} ", file_label);
+                left_spans.push(left_file.into());
+
+                let cursor_label = format!(
+                    " {}:{} ",
+                    instance.cursor.row + 1,
+                    instance.cursor.column + 1,
+                );
+                let modified_label = format!(" {} ", if buffer.modified { "U" } else { "" });
+                let keybind_label = format!(" {} ", self.state.keybind_handler.running_sequence);
+                let log_label = format!(
+                    " {} ",
+                    self.state.log_messages.last().unwrap_or(&String::new())
+                );
+                let right_len = cursor_label.chars().count()
+                    + modified_label.chars().count()
+                    + keybind_label.chars().count()
+                    + log_label.chars().count();
+                let status_area_width = v_layout[1].width as usize;
+                let max_right = status_area_width.saturating_sub(10).max(1);
+                let right_width = right_len.min(max_right).min(status_area_width) as u16;
+                let status_layout = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Min(1), Constraint::Length(right_width)])
+                    .split(v_layout[1]);
+                let left_status =
+                    widgets::Paragraph::new(text::Line::from(left_spans)).style(status_bar_style);
+                let right_status = widgets::Paragraph::new(text::Line::from(vec![
+                    cursor_label.into(),
+                    modified_label.into(),
+                    keybind_label.into(),
+                    log_label.into(),
+                ]))
+                .style(status_bar_style)
+                .alignment(ratatui::layout::Alignment::Right);
+                frame.render_widget(left_status, status_layout[0]);
+                frame.render_widget(right_status, status_layout[1]);
+            }
+
+            // Render diagnostics overlay
+            if self.state.diagnostics_overlay.should_render() {
+                let area = Rect {
+                    x: frame.area().width * 7 / 8 - 4,
+                    y: 2,
+                    width: frame.area().width / 8,
+                    height: frame.area().height - 4,
+                };
+                let diagnostics_info =
+                    widgets::Paragraph::new(self.state.diagnostics_overlay.content.clone())
+                        .wrap(widgets::Wrap { trim: false });
+                frame.render_widget(diagnostics_info, area);
+            }
+
+            // Render signature information
+            if self.state.signature_information.should_render()
+                && self.state.relative_cursor.row > 1
+                && self.state.relative_cursor.row < self.state.viewport_rows().saturating_sub(1)
+            {
+                let popup_area = Rect {
+                    x: self.state.relative_cursor.column as u16 + h_layout[1].x + 1,
+                    y: self.state.relative_cursor.row as u16 + h_layout[1].y - 1,
+                    width: (self.state.signature_information.content.len() as u16).min(
+                        frame.area().width
+                            - self.state.relative_cursor.column as u16
+                            - h_layout[1].x
+                            - 3,
+                    ),
+                    height: 1,
+                };
+                let signature_block = widgets::Block::default().style(
+                    Style::new()
+                        .bg(color_from_rgb(self.state.preferences.theme.modal_bg))
+                        .fg(color_from_rgb(self.state.preferences.theme.modal_text)),
+                );
+
+                let signature_information =
+                    widgets::Paragraph::new(self.state.signature_information.content.clone())
+                        .block(signature_block);
+                frame.render_widget(widgets::Clear, popup_area);
+                frame.render_widget(signature_information, popup_area);
+            }
+
+            // Render Completion Items
+            if self.state.completion_menu.active {
+                let offset_y = if viewport_rows - self.state.completion_menu.max_items - 1
+                    < self.state.relative_cursor.row
+                {
+                    self.state.completion_menu.max_items as u16
+                } else {
+                    0
+                };
+                let popup_area = Rect {
+                    x: (self.state.relative_cursor.column as u16 + h_layout[1].x + 1)
+                        .min(frame.area().width - 35),
+                    y: self.state.relative_cursor.row as u16 + h_layout[1].y + 1 - offset_y,
+                    width: 30,
+                    height: self.state.completion_menu.max_items as u16,
+                };
+                let completion_list_block = widgets::Block::default().style(
+                    Style::new()
+                        .bg(color_from_rgb(self.state.preferences.theme.modal_bg))
+                        .fg(color_from_rgb(self.state.preferences.theme.modal_text)),
+                );
+
+                let completion_list = self
+                    .state
+                    .completion_menu
+                    .items
+                    .iter()
+                    .map(|item| item.label.clone())
+                    .collect::<widgets::List>()
+                    .highlight_style(
+                        Style::new().fg(color_from_rgb(self.state.preferences.theme.modal_primary)),
+                    )
+                    .block(completion_list_block);
+                frame.render_widget(widgets::Clear, popup_area);
+                let mut list_state = widgets::ListState::default();
+                list_state.select(self.state.completion_menu.selection);
+                frame.render_stateful_widget(completion_list, popup_area, &mut list_state);
+            }
+        });
     }
 }

--- a/crates/rift_tui/src/main.rs
+++ b/crates/rift_tui/src/main.rs
@@ -6,11 +6,15 @@ fn main() -> anyhow::Result<()> {
 
     tracing::info!("Rift session starting (tui)");
 
-    let mut app = app::App::new();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    let mut app = app::App::new(rt.handle().clone());
 
     let mut terminal = ratatui::init();
     terminal.clear()?;
-    app.run(terminal)?;
+    app.run(&rt, terminal)?;
     ratatui::restore();
 
     tracing::info!("Rift session exiting (tui)");


### PR DESCRIPTION
## Summary
- Replace synchronous `try_recv` + `sleep` polling in TUI and server main loops with event-driven `tokio::select!` on `LocalSet`, eliminating 8-15ms per-round-trip latency on the ~112 sequential RPC calls during RSL initialization
- Refactor `EditorState` to accept a `Handle` instead of owning a `Runtime`, and switch all LSP/RSL/concurrent sends from `blocking_send` to non-blocking `try_send`
- Add unified LSP message channel that aggregates responses from all language servers, and use crossterm `EventStream` for async keyboard input in TUI

## Test plan
- [x] `cargo build` — all crates compile
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all tests pass
- [x] `cargo run -p rift_tui --release` — editor starts, RSL init is noticeably faster
- [x] `cargo run -p rift_tui --release -- --no-lsp --no-audio` — works without LSP/audio
- [x] `cargo run -p rift_server --release -- --no-audio` — web frontend works
- [x] Open a Rust file — LSP completions, hover, go-to-definition, diagnostics work
- [x] All RSL keybinds work (space+c for agent, file explorer, etc.)
- [x] CPU usage at idle is near zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)